### PR TITLE
[Feat] 검색 페이지 UI 구현

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		2C39AA682970481F000C6F71 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C39AA672970481F000C6F71 /* HomeViewController.swift */; };
 		2C39AA7B29705524000C6F71 /* UIColor++Extenstions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C39AA7A29705524000C6F71 /* UIColor++Extenstions.swift */; };
 		2C39AA7F29705B4C000C6F71 /* UITabBarItem++Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C39AA7E29705B4C000C6F71 /* UITabBarItem++Extensions.swift */; };
+		2C4041CE29ACD94D009247E7 /* SearchBarContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041CD29ACD94D009247E7 /* SearchBarContainerView.swift */; };
 		2C4DD36C29754B3A0027CE40 /* HomeTopCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36B29754B3A0027CE40 /* HomeTopCell.swift */; };
 		2C4DD36E29754B410027CE40 /* HomeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36D29754B410027CE40 /* HomeCell.swift */; };
 		2C4DD37029756D3A0027CE40 /* HomeCellHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36F29756D3A0027CE40 /* HomeCellHeaderView.swift */; };
@@ -172,6 +173,7 @@
 		2C39AA7629704C2F000C6F71 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2C39AA7A29705524000C6F71 /* UIColor++Extenstions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor++Extenstions.swift"; sourceTree = "<group>"; };
 		2C39AA7E29705B4C000C6F71 /* UITabBarItem++Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarItem++Extensions.swift"; sourceTree = "<group>"; };
+		2C4041CD29ACD94D009247E7 /* SearchBarContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarContainerView.swift; sourceTree = "<group>"; };
 		2C4DD36B29754B3A0027CE40 /* HomeTopCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTopCell.swift; sourceTree = "<group>"; };
 		2C4DD36D29754B410027CE40 /* HomeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCell.swift; sourceTree = "<group>"; };
 		2C4DD36F29756D3A0027CE40 /* HomeCellHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellHeaderView.swift; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 		2C04246729A3A983009CF0FE /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				2C4041CC29ACD92A009247E7 /* View */,
 				2C6DAD0929A76EF9003F0E98 /* Reactor */,
 				2C6DAD0829A76EF3003F0E98 /* VIewController */,
 				2C04246829A3A992009CF0FE /* SearchViewController.swift */,
@@ -616,6 +619,14 @@
 				2C04249E29A67F07009CF0FE /* UIButton++Extenstions.swift */,
 			);
 			path = Extenstions;
+			sourceTree = "<group>";
+		};
+		2C4041CC29ACD92A009247E7 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				2C4041CD29ACD94D009247E7 /* SearchBarContainerView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		2C4DD366297547620027CE40 /* View */ = {
@@ -1092,6 +1103,7 @@
 				2C710EF1297BCC33006BE23B /* UIViewController++Extenstions.swift in Sources */,
 				CA5D24A12983EFAB0014ADF8 /* UIStackView++Extenstions.swift in Sources */,
 				2C04248B29A4FABA009CF0FE /* CommentSection.swift in Sources */,
+				2C4041CE29ACD94D009247E7 /* SearchBarContainerView.swift in Sources */,
 				2C04249229A504D3009CF0FE /* CommentDetailViewController.swift in Sources */,
 				2C1BD6C62998D34F0059A43D /* DetailBottomView.swift in Sources */,
 				2CDFFDD92983F9FB00F60304 /* NewsView.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		2C39AA7B29705524000C6F71 /* UIColor++Extenstions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C39AA7A29705524000C6F71 /* UIColor++Extenstions.swift */; };
 		2C39AA7F29705B4C000C6F71 /* UITabBarItem++Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C39AA7E29705B4C000C6F71 /* UITabBarItem++Extensions.swift */; };
 		2C4041CE29ACD94D009247E7 /* SearchBarContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041CD29ACD94D009247E7 /* SearchBarContainerView.swift */; };
+		2C4041D029ACDC13009247E7 /* SearchKeywordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041CF29ACDC13009247E7 /* SearchKeywordViewController.swift */; };
+		2C4041D229ACDC58009247E7 /* SearchListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041D129ACDC58009247E7 /* SearchListViewController.swift */; };
+		2C4041D429ACDC67009247E7 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041D329ACDC67009247E7 /* SearchResultViewController.swift */; };
 		2C4DD36C29754B3A0027CE40 /* HomeTopCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36B29754B3A0027CE40 /* HomeTopCell.swift */; };
 		2C4DD36E29754B410027CE40 /* HomeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36D29754B410027CE40 /* HomeCell.swift */; };
 		2C4DD37029756D3A0027CE40 /* HomeCellHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36F29756D3A0027CE40 /* HomeCellHeaderView.swift */; };
@@ -174,6 +177,9 @@
 		2C39AA7A29705524000C6F71 /* UIColor++Extenstions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor++Extenstions.swift"; sourceTree = "<group>"; };
 		2C39AA7E29705B4C000C6F71 /* UITabBarItem++Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarItem++Extensions.swift"; sourceTree = "<group>"; };
 		2C4041CD29ACD94D009247E7 /* SearchBarContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarContainerView.swift; sourceTree = "<group>"; };
+		2C4041CF29ACDC13009247E7 /* SearchKeywordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeywordViewController.swift; sourceTree = "<group>"; };
+		2C4041D129ACDC58009247E7 /* SearchListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListViewController.swift; sourceTree = "<group>"; };
+		2C4041D329ACDC67009247E7 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
 		2C4DD36B29754B3A0027CE40 /* HomeTopCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTopCell.swift; sourceTree = "<group>"; };
 		2C4DD36D29754B410027CE40 /* HomeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCell.swift; sourceTree = "<group>"; };
 		2C4DD36F29756D3A0027CE40 /* HomeCellHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellHeaderView.swift; sourceTree = "<group>"; };
@@ -292,7 +298,6 @@
 				2C4041CC29ACD92A009247E7 /* View */,
 				2C6DAD0929A76EF9003F0E98 /* Reactor */,
 				2C6DAD0829A76EF3003F0E98 /* VIewController */,
-				2C04246829A3A992009CF0FE /* SearchViewController.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -645,6 +650,10 @@
 		2C6DAD0829A76EF3003F0E98 /* VIewController */ = {
 			isa = PBXGroup;
 			children = (
+				2C04246829A3A992009CF0FE /* SearchViewController.swift */,
+				2C4041CF29ACDC13009247E7 /* SearchKeywordViewController.swift */,
+				2C4041D129ACDC58009247E7 /* SearchListViewController.swift */,
+				2C4041D329ACDC67009247E7 /* SearchResultViewController.swift */,
 			);
 			path = VIewController;
 			sourceTree = "<group>";
@@ -1128,12 +1137,14 @@
 				2C1BD6C22997A35C0059A43D /* CommentHeaderView.swift in Sources */,
 				2CDFFDD52983F9D300F60304 /* NewsCell.swift in Sources */,
 				2C4DEECD299BBF7500DE9778 /* UINavigationItem++Extenstions.swift in Sources */,
+				2C4041D029ACDC13009247E7 /* SearchKeywordViewController.swift in Sources */,
 				CAFA451329AB7E7B00ACF2C1 /* ChoiceEmailViewController.swift in Sources */,
 				2C4DD37029756D3A0027CE40 /* HomeCellHeaderView.swift in Sources */,
 				2C04246B29A3B3E3009CF0FE /* HomeCellReactor.swift in Sources */,
 				2C04249D29A65C32009CF0FE /* CommentWriteReactor.swift in Sources */,
 				CA914491297E7EE600762BC0 /* LoginViewModel.swift in Sources */,
 				2C39AA642970480E000C6F71 /* MenuViewController.swift in Sources */,
+				2C4041D229ACDC58009247E7 /* SearchListViewController.swift in Sources */,
 				2C1BD6C0299798660059A43D /* TastingNoteView.swift in Sources */,
 				2C39AA60297047F9000C6F71 /* DrawerViewController.swift in Sources */,
 				2C04249F29A67F07009CF0FE /* UIButton++Extenstions.swift in Sources */,
@@ -1166,6 +1177,7 @@
 				2C4DD3742976E1A70027CE40 /* HomeView.swift in Sources */,
 				2C710EFC297C15DF006BE23B /* MyPageCell.swift in Sources */,
 				2C39AA7B29705524000C6F71 /* UIColor++Extenstions.swift in Sources */,
+				2C4041D429ACDC67009247E7 /* SearchResultViewController.swift in Sources */,
 				2C04248529A4D859009CF0FE /* CommentListReactor.swift in Sources */,
 				2C04249429A50DB4009CF0FE /* CommentDetailReactor.swift in Sources */,
 				2C04246E29A3E112009CF0FE /* DetailViewReactor.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		2C4041D029ACDC13009247E7 /* SearchKeywordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041CF29ACDC13009247E7 /* SearchKeywordViewController.swift */; };
 		2C4041D229ACDC58009247E7 /* SearchListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041D129ACDC58009247E7 /* SearchListViewController.swift */; };
 		2C4041D429ACDC67009247E7 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041D329ACDC67009247E7 /* SearchResultViewController.swift */; };
+		2C4041D629AD1211009247E7 /* SearchListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041D529AD1211009247E7 /* SearchListTableViewCell.swift */; };
 		2C4DD36C29754B3A0027CE40 /* HomeTopCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36B29754B3A0027CE40 /* HomeTopCell.swift */; };
 		2C4DD36E29754B410027CE40 /* HomeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36D29754B410027CE40 /* HomeCell.swift */; };
 		2C4DD37029756D3A0027CE40 /* HomeCellHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36F29756D3A0027CE40 /* HomeCellHeaderView.swift */; };
@@ -180,6 +181,7 @@
 		2C4041CF29ACDC13009247E7 /* SearchKeywordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKeywordViewController.swift; sourceTree = "<group>"; };
 		2C4041D129ACDC58009247E7 /* SearchListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListViewController.swift; sourceTree = "<group>"; };
 		2C4041D329ACDC67009247E7 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
+		2C4041D529AD1211009247E7 /* SearchListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListTableViewCell.swift; sourceTree = "<group>"; };
 		2C4DD36B29754B3A0027CE40 /* HomeTopCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTopCell.swift; sourceTree = "<group>"; };
 		2C4DD36D29754B410027CE40 /* HomeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCell.swift; sourceTree = "<group>"; };
 		2C4DD36F29756D3A0027CE40 /* HomeCellHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellHeaderView.swift; sourceTree = "<group>"; };
@@ -630,6 +632,7 @@
 			isa = PBXGroup;
 			children = (
 				2C4041CD29ACD94D009247E7 /* SearchBarContainerView.swift */,
+				2C4041D529AD1211009247E7 /* SearchListTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1179,6 +1182,7 @@
 				2C39AA7B29705524000C6F71 /* UIColor++Extenstions.swift in Sources */,
 				2C4041D429ACDC67009247E7 /* SearchResultViewController.swift in Sources */,
 				2C04248529A4D859009CF0FE /* CommentListReactor.swift in Sources */,
+				2C4041D629AD1211009247E7 /* SearchListTableViewCell.swift in Sources */,
 				2C04249429A50DB4009CF0FE /* CommentDetailReactor.swift in Sources */,
 				2C04246E29A3E112009CF0FE /* DetailViewReactor.swift in Sources */,
 				CAFA44FF29AB7C6600ACF2C1 /* PwTextFieldState.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -75,6 +75,9 @@
 		2C710EFC297C15DF006BE23B /* MyPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C710EFB297C15DF006BE23B /* MyPageCell.swift */; };
 		2C710EFF297C1840006BE23B /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C710EFE297C183F006BE23B /* MyPageViewModel.swift */; };
 		2C724E2F29AB1A120057D9B4 /* CommentListTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C724E2E29AB1A120057D9B4 /* CommentListTopView.swift */; };
+		2CAB7A9829B07A2300E74809 /* SearchResultTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */; };
+		2CAB7A9A29B08BBA00E74809 /* SearchResultCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */; };
+		2CAB7A9D29B08E4100E74809 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9C29B08E4100E74809 /* Product.swift */; };
 		2CAD9635298E469200974500 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAD9634298E469200974500 /* DetailViewController.swift */; };
 		2CAD9637298E483800974500 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAD9636298E483800974500 /* DetailView.swift */; };
 		2CAD9639298E4C1D00974500 /* PerfumeInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAD9638298E4C1D00974500 /* PerfumeInfoView.swift */; };
@@ -196,6 +199,9 @@
 		2C710EFB297C15DF006BE23B /* MyPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCell.swift; sourceTree = "<group>"; };
 		2C710EFE297C183F006BE23B /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		2C724E2E29AB1A120057D9B4 /* CommentListTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListTopView.swift; sourceTree = "<group>"; };
+		2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultTopView.swift; sourceTree = "<group>"; };
+		2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCollectionViewCell.swift; sourceTree = "<group>"; };
+		2CAB7A9C29B08E4100E74809 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		2CAD9634298E469200974500 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		2CAD9636298E483800974500 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		2CAD9638298E4C1D00974500 /* PerfumeInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfumeInfoView.swift; sourceTree = "<group>"; };
@@ -297,6 +303,7 @@
 		2C04246729A3A983009CF0FE /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				2CAB7A9B29B08E3200E74809 /* Model */,
 				2C4041CC29ACD92A009247E7 /* View */,
 				2C6DAD0929A76EF9003F0E98 /* Reactor */,
 				2C6DAD0829A76EF3003F0E98 /* VIewController */,
@@ -633,6 +640,9 @@
 			children = (
 				2C4041CD29ACD94D009247E7 /* SearchBarContainerView.swift */,
 				2C4041D529AD1211009247E7 /* SearchListTableViewCell.swift */,
+				2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */,
+				2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */,
+				2CAB7A9C29B08E4100E74809 /* Product.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -685,6 +695,13 @@
 				2C710EFE297C183F006BE23B /* MyPageViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		2CAB7A9B29B08E3200E74809 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		2CAD9630298E465600974500 /* Detail */ = {
@@ -1120,6 +1137,7 @@
 				2C1BD6C62998D34F0059A43D /* DetailBottomView.swift in Sources */,
 				2CDFFDD92983F9FB00F60304 /* NewsView.swift in Sources */,
 				CAFA450329AB7CEE00ACF2C1 /* PwRegisetrViewModel.swift in Sources */,
+				2CAB7A9A29B08BBA00E74809 /* SearchResultCollectionViewCell.swift in Sources */,
 				2C39AA7F29705B4C000C6F71 /* UITabBarItem++Extensions.swift in Sources */,
 				2CDFFDD72983F9E500F60304 /* NewsCellFooterView.swift in Sources */,
 				CA914498297E873300762BC0 /* UIFont++Extenstions.swift in Sources */,
@@ -1149,12 +1167,14 @@
 				2C39AA642970480E000C6F71 /* MenuViewController.swift in Sources */,
 				2C4041D229ACDC58009247E7 /* SearchListViewController.swift in Sources */,
 				2C1BD6C0299798660059A43D /* TastingNoteView.swift in Sources */,
+				2CAB7A9829B07A2300E74809 /* SearchResultTopView.swift in Sources */,
 				2C39AA60297047F9000C6F71 /* DrawerViewController.swift in Sources */,
 				2C04249F29A67F07009CF0FE /* UIButton++Extenstions.swift in Sources */,
 				2C724E2F29AB1A120057D9B4 /* CommentListTopView.swift in Sources */,
 				CAFA451129AB7E4000ACF2C1 /* PaddingLabel.swift in Sources */,
 				CAFA450129AB7CDD00ACF2C1 /* ChocieEmailViewModel.swift in Sources */,
 				2C4DD36E29754B410027CE40 /* HomeCell.swift in Sources */,
+				2CAB7A9D29B08E4100E74809 /* Product.swift in Sources */,
 				2CAD9635298E469200974500 /* DetailViewController.swift in Sources */,
 				2C39AA682970481F000C6F71 /* HomeViewController.swift in Sources */,
 				2C04249B29A656BB009CF0FE /* CommentWriteViewController.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIButton++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIButton++Extenstions.swift
@@ -37,4 +37,35 @@ extension UIButton {
         self.layer.cornerRadius = 10
         self.backgroundColor = .customColor(.gray1)
     }
+    
+    func makeCategoryButton(_ title: String) {
+        
+        var selectedConfig = UIButton.Configuration.plain()
+        var normalConfig = UIButton.Configuration.plain()
+        var attribute = AttributedString.init(title)
+        attribute.font = .customFont(.pretendard, 14)
+                
+        selectedConfig.baseBackgroundColor = .white
+        selectedConfig.baseForegroundColor = .white
+        normalConfig.baseForegroundColor = .customColor(.gray3)
+        normalConfig.baseBackgroundColor = .white
+
+        selectedConfig.attributedTitle = attribute
+        normalConfig.attributedTitle = attribute
+        
+        self.configurationUpdateHandler = {
+            switch $0.state {
+            case .selected:
+                $0.configuration = selectedConfig
+                $0.backgroundColor = .black
+            default:
+                $0.configuration = normalConfig
+                $0.backgroundColor = .white
+                $0.layer.borderColor = UIColor.customColor(.gray3).cgColor
+                $0.layer.borderWidth = 1
+            }
+        }
+        
+        self.layer.cornerRadius = 10
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/ViewController/DetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/ViewController/DetailViewController.swift
@@ -147,6 +147,9 @@ extension DetailViewController {
         
         reactor.state
             .map { $0.isPresentSearchVC }
+            .do(onNext: {
+                print($0)
+            })
             .distinctUntilChanged()
             .filter { $0 }
             .map { _ in }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
@@ -11,6 +11,7 @@ import RxSwift
 class SearchReactor: Reactor {
     
     enum Action {
+        case keywordViewDidLoad
         case didTapBackButton
         case didChangeTextField
         case didEndTextField
@@ -20,6 +21,7 @@ class SearchReactor: Reactor {
         case isPopVC(Bool)
         case isChangeToResultVC(Bool)
         case isChangeToListVC(Bool)
+        case setKeyword([String])
     }
     
     struct State {
@@ -27,12 +29,15 @@ class SearchReactor: Reactor {
         var isPopVC: Bool = false
         var isChangeTextField: Bool = false
         var isEndTextField: Bool = false
+        var keywords: [String] = []
     }
     
     var initialState = State()
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .keywordViewDidLoad:
+            return requestKeyword()
         case .didTapBackButton:
             return .concat([
                 .just(.isPopVC(true)),
@@ -55,6 +60,8 @@ class SearchReactor: Reactor {
         var state = state
         
         switch mutation {
+        case .setKeyword(let keywords):
+            state.keywords = keywords
         case .isPopVC(let isPop):
             state.isPopVC = isPop
         case .isChangeToListVC(let isChange):
@@ -64,5 +71,19 @@ class SearchReactor: Reactor {
         }
         
         return state
+    }
+}
+
+extension SearchReactor {
+    
+    func requestKeyword() -> Observable<Mutation> {
+        
+        // TODO: - 서버 통신해서 키워드 받아오기
+        
+        let data = ["자연", "도손", "오프레옹", "롬브로단로", "우드앤세이지", "딥티크", "르라보", "선물", "크리스찬디올", "존바바토스", "30대"]
+        
+        return .concat([
+            .just(.setKeyword(data))
+        ])
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
@@ -12,15 +12,21 @@ class SearchReactor: Reactor {
     
     enum Action {
         case didTapBackButton
+        case didChangeTextField
+        case didEndTextField
     }
     
     enum Mutation {
         case isPopVC(Bool)
+        case isChangeToResultVC(Bool)
+        case isChangeToListVC(Bool)
     }
     
     struct State {
         var Content: String = ""
         var isPopVC: Bool = false
+        var isChangeTextField: Bool = false
+        var isEndTextField: Bool = false
     }
     
     var initialState = State()
@@ -32,6 +38,16 @@ class SearchReactor: Reactor {
                 .just(.isPopVC(true)),
                 .just(.isPopVC(false))
             ])
+        case .didChangeTextField:
+            return .concat([
+                .just(.isChangeToListVC(true)),
+                .just(.isChangeToListVC(false))
+            ])
+        case .didEndTextField:
+            return .concat([
+                .just(.isChangeToResultVC(true)),
+                .just(.isChangeToResultVC(false))
+            ])
         }
     }
     
@@ -41,6 +57,10 @@ class SearchReactor: Reactor {
         switch mutation {
         case .isPopVC(let isPop):
             state.isPopVC = isPop
+        case .isChangeToListVC(let isChange):
+            state.isChangeTextField = isChange
+        case .isChangeToResultVC(let isEnd):
+            state.isEndTextField = isEnd
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
@@ -15,6 +15,10 @@ class SearchReactor: Reactor {
         case didTapBackButton
         case didChangeTextField
         case didEndTextField
+        case didTapProductButton
+        case didTapBrandButton
+        case didTapPostButton
+        case didTapHpediaButton
     }
     
     enum Mutation {
@@ -23,6 +27,11 @@ class SearchReactor: Reactor {
         case isChangeToListVC(Bool, Int?)
         case setKeyword([String])
         case setList([String])
+        case setResultProduct([Product])
+        case setProductButtonState(Bool)
+        case setBrandButtonState(Bool)
+        case setPostButtonState(Bool)
+        case setHpediaButtonState(Bool)
     }
     
     struct State {
@@ -32,8 +41,13 @@ class SearchReactor: Reactor {
         var isEndTextField: Bool = false
         var keywords: [String] = []
         var lists: [String] = [] // 연관 검색어 리스트
+        var resultProduct: [Product] = []
         var nowPage: Int = 1 // 현재 보여지고 있는 페이지
         var prePage: Int = 0 // 이전 페이지
+        var isSelectedProductButton: Bool = true
+        var isSelectedBrandButton: Bool = false
+        var isSelectedPostButton: Bool = false
+        var isSelectedHpediaButton: Bool = false
     }
     
     var initialState = State()
@@ -56,8 +70,21 @@ class SearchReactor: Reactor {
         case .didEndTextField:
             return .concat([
                 .just(.isChangeToResultVC(true, 3)),
+                requestResult(),
                 .just(.isChangeToResultVC(false, nil))
             ])
+        case .didTapProductButton:
+            return .just(.setProductButtonState(true))
+
+        case .didTapBrandButton:
+            return .just(.setBrandButtonState(true))
+
+        case .didTapPostButton:
+            return .just(.setPostButtonState(true))
+
+        case .didTapHpediaButton:
+            return .just(.setHpediaButtonState(true))
+        
         }
     }
     
@@ -69,6 +96,8 @@ class SearchReactor: Reactor {
             state.keywords = keywords
         case .setList(let lists):
             state.lists = lists
+        case .setResultProduct(let products):
+            state.resultProduct = products
         case .isPopVC(let isPop):
             state.isPopVC = isPop
         case .isChangeToListVC(let isChange, let nowPage):
@@ -84,14 +113,38 @@ class SearchReactor: Reactor {
             
         case .isChangeToResultVC(let isEnd, let nowPage):
             state.isEndTextField = isEnd
-
+            
             if let nowPage = nowPage {
                 state.prePage = state.nowPage
                 state.nowPage = nowPage
             }
+            
+        case .setProductButtonState(let isSelected):
+            state.isSelectedProductButton = isSelected
+            state.isSelectedBrandButton = false
+            state.isSelectedPostButton = false
+            state.isSelectedHpediaButton = false
+            
+        case .setBrandButtonState(let isSelected):
+            state.isSelectedBrandButton = isSelected
+            state.isSelectedProductButton = false
+            state.isSelectedPostButton = false
+            state.isSelectedHpediaButton = false
+            
+        case .setPostButtonState(let isSelected):
+            state.isSelectedPostButton = isSelected
+            state.isSelectedBrandButton = false
+            state.isSelectedProductButton = false
+            state.isSelectedHpediaButton = false
+            
+        case .setHpediaButtonState(let isSelected):
+            state.isSelectedHpediaButton = isSelected
+            state.isSelectedBrandButton = false
+            state.isSelectedPostButton = false
+            state.isSelectedProductButton = false
         }
+        
         return state
-
     }
 }
 
@@ -124,5 +177,12 @@ extension SearchReactor {
                      "랑방 잔느"]
         
         return .just(.setList(data))
+    }
+    
+    func requestResult() -> Observable<Mutation> {
+        
+        let data: [Product] = [Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛")]
+        
+        return .just(.setResultProduct(data))
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/SearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/SearchViewController.swift
@@ -72,9 +72,13 @@ extension SearchViewController {
     func configureNavigationBar() {
      
         let backButtonItem = UIBarButtonItem(customView: backButton)
-                
+        
+        let searchBarWrapper = SearchBarContainerView(customSearchBar: searchBar)
+        
+        searchBarWrapper.frame = CGRect(x: 0, y: 0, width: self.navigationController!.view.frame.size.width - 42, height: 30)
+        
         self.navigationItem.leftBarButtonItems = [backButtonItem]
         
-        self.navigationItem.titleView = searchBar
+        self.navigationItem.titleView = searchBarWrapper
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchKeywordViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchKeywordViewController.swift
@@ -6,24 +6,43 @@
 //
 
 import UIKit
+import SnapKit
+import Then
+import TagListView
 
 class SearchKeywordViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.backgroundColor = .yellow
-        // Do any additional setup after loading the view.
+    // MARK: - UI Component
+    lazy var keywordList = TagListView().then {
+        $0.marginY = 8
+        $0.marginX = 4
+        $0.borderColor = .white
+        $0.cornerRadius = 12
+        $0.tagBackgroundColor = .black
+        $0.textColor = .white
+        $0.alignment = .center
+        $0.textFont = .customFont(.pretendard, 14)
+        $0.paddingY = 5
+        $0.paddingX = 12
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
     }
-    */
+}
 
+extension SearchKeywordViewController {
+    
+    func configureUI() {
+        
+        view.addSubview(keywordList)
+        
+        keywordList.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(100)
+        }
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchKeywordViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchKeywordViewController.swift
@@ -1,0 +1,29 @@
+//
+//  SearchKeywordViewController.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/02/27.
+//
+
+import UIKit
+
+class SearchKeywordViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .yellow
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchListViewController.swift
@@ -1,0 +1,29 @@
+//
+//  SearchListViewController.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/02/27.
+//
+
+import UIKit
+
+class SearchListViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .green
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchListViewController.swift
@@ -9,21 +9,32 @@ import UIKit
 
 class SearchListViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.backgroundColor = .green
-        // Do any additional setup after loading the view.
+    // MARK: - UI Component
+    
+    lazy var tableView = UITableView().then {
+        $0.register(SearchListTableViewCell.self, forCellReuseIdentifier: SearchListTableViewCell.identifier)
+        $0.separatorStyle = .none
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureUI()
     }
-    */
+}
 
+extension SearchListViewController {
+    
+    // MARK: - Configure
+    
+    func configureUI() {
+        
+        view.addSubview(tableView)
+        
+        tableView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(26)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchResultViewController.swift
@@ -8,22 +8,57 @@
 import UIKit
 
 class SearchResultViewController: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.backgroundColor = .blue
-        // Do any additional setup after loading the view.
+    
+    // MARK: - UI Component
+    
+    lazy var topView = SearchResultTopView()
+    
+    lazy var layout = UICollectionViewFlowLayout()
+    
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout).then {
+        $0.register(SearchResultCollectionViewCell.self, forCellWithReuseIdentifier: SearchResultCollectionViewCell.identifier)
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
     }
-    */
+}
 
+extension SearchResultViewController {
+    
+    // MARK: - Configure
+    func configureUI() {
+
+        collectionView.delegate = self
+        
+        [   topView,
+            collectionView
+        ]   .forEach { view.addSubview($0) }
+        
+        topView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(42)
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(topView.snp.bottom).offset(3)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+}
+
+extension SearchResultViewController: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        let width = (UIScreen.main.bounds.width - 40) / 2
+        let height = width + 82
+        return CGSize(width: width, height: height)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchResultViewController.swift
@@ -1,0 +1,29 @@
+//
+//  SearchResultViewController.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/02/27.
+//
+
+import UIKit
+
+class SearchResultViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .blue
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
@@ -79,6 +79,25 @@ extension SearchViewController {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        ResultVC.topView.productButton.rx.tap
+            .map { Reactor.Action.didTapProductButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        ResultVC.topView.brandButton.rx.tap
+            .map { Reactor.Action.didTapBrandButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        ResultVC.topView.postButton.rx.tap
+            .map { Reactor.Action.didTapPostButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        ResultVC.topView.hpediaButton.rx.tap
+            .map { Reactor.Action.didTapHpediaButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         // MARK: - State
         
         // 이전 뷰 컨트롤러로 이동
@@ -116,7 +135,14 @@ extension SearchViewController {
                 self.keywordVC.keywordList.addTags($0)
             })
             .disposed(by: disposeBag)
-        
+        reactor.state
+            .map { $0.resultProduct }
+            .distinctUntilChanged()
+            .bind(to: self.ResultVC.collectionView.rx.items(
+                cellIdentifier: SearchResultCollectionViewCell.identifier, cellType: SearchResultCollectionViewCell.self)) { index, item, cell in
+                    cell.updateCell(item)
+            }
+            .disposed(by: disposeBag)
         // 연관 검색어 값이 바뀌면 tableView에 바인딩
         reactor.state
             .map { $0.lists }
@@ -127,6 +153,8 @@ extension SearchViewController {
                     cell.updateCell(item)
             }
             .disposed(by: disposeBag)
+
+
 
         // 화면이 바뀌면 이전 페이지(VC)의 자식관계를 해지시켜줌
         reactor.state
@@ -144,6 +172,30 @@ extension SearchViewController {
                     break
                 }
             })
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isSelectedProductButton }
+            .distinctUntilChanged()
+            .bind(to: ResultVC.topView.productButton.rx.isSelected)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isSelectedBrandButton }
+            .distinctUntilChanged()
+            .bind(to: ResultVC.topView.brandButton.rx.isSelected )
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isSelectedPostButton }
+            .distinctUntilChanged()
+            .bind(to: ResultVC.topView.postButton.rx.isSelected)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isSelectedHpediaButton }
+            .distinctUntilChanged()
+            .bind(to: ResultVC.topView.hpediaButton.rx.isSelected )
             .disposed(by: disposeBag)
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
@@ -18,12 +18,18 @@ class SearchViewController: UIViewController, View {
     // MARK: - Properties
     
     var disposeBag = DisposeBag()
+    private var page = 0
     
     // MARK: - UI Component
     
-    let backButton = UIButton().makeImageButton(UIImage(named: "backButton")!)
+    private lazy var keywordVC = SearchKeywordViewController()
+    private lazy var listVC = SearchListViewController()
+    private lazy var ResultVC = SearchResultViewController()
+    private lazy var containerView = UIView()
     
-    let searchBar = UISearchBar().then {
+    lazy var backButton = UIButton().makeImageButton(UIImage(named: "backButton")!)
+    
+    lazy var searchBar = UISearchBar().then {
         $0.showsBookmarkButton = true
         $0.setImage(UIImage(named: "clearButton"), for: .clear, state: .normal)
         $0.setImage(UIImage(named: "search")?.withTintColor(.customColor(.gray3)), for: .bookmark, state: .normal)
@@ -44,6 +50,8 @@ class SearchViewController: UIViewController, View {
 
 extension SearchViewController {
     
+    
+    // MARK: - Binding
     func bind(reactor: SearchReactor) {
         // MARK: - Action
         
@@ -65,9 +73,24 @@ extension SearchViewController {
             .disposed(by: disposeBag)
     }
     
+    // MARK: - Configure
     func configureUI() {
         view.backgroundColor = .white
+        
+        [   keywordVC,
+            listVC,
+            ResultVC
+        ]   .forEach {  self.addChild($0)   }
+        
+        [   containerView
+        ]   .forEach { view.addSubview($0) }
+        
+        containerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
     }
+    
     
     func configureNavigationBar() {
      

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
@@ -62,6 +62,7 @@ extension SearchViewController {
         
         // Text 입력
         searchBar.rx.text.orEmpty
+            .distinctUntilChanged()
             .filter { $0 != "" }
             .map { _ in Reactor.Action.didChangeTextField }
             .bind(to: reactor.action)
@@ -79,25 +80,30 @@ extension SearchViewController {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        // 상품 버튼 클릭
         ResultVC.topView.productButton.rx.tap
             .map { Reactor.Action.didTapProductButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        // 브랜드 버튼 클릭
         ResultVC.topView.brandButton.rx.tap
             .map { Reactor.Action.didTapBrandButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        // 포스트 버튼 클릭
         ResultVC.topView.postButton.rx.tap
             .map { Reactor.Action.didTapPostButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        // Hpedia 버튼 클릭
         ResultVC.topView.hpediaButton.rx.tap
             .map { Reactor.Action.didTapHpediaButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
         // MARK: - State
         
         // 이전 뷰 컨트롤러로 이동
@@ -135,6 +141,7 @@ extension SearchViewController {
                 self.keywordVC.keywordList.addTags($0)
             })
             .disposed(by: disposeBag)
+        
         reactor.state
             .map { $0.resultProduct }
             .distinctUntilChanged()
@@ -143,6 +150,7 @@ extension SearchViewController {
                     cell.updateCell(item)
             }
             .disposed(by: disposeBag)
+        
         // 연관 검색어 값이 바뀌면 tableView에 바인딩
         reactor.state
             .map { $0.lists }
@@ -153,8 +161,6 @@ extension SearchViewController {
                     cell.updateCell(item)
             }
             .disposed(by: disposeBag)
-
-
 
         // 화면이 바뀌면 이전 페이지(VC)의 자식관계를 해지시켜줌
         reactor.state
@@ -174,29 +180,34 @@ extension SearchViewController {
             })
             .disposed(by: disposeBag)
         
+        // 상품 버튼 상태 변화
         reactor.state
             .map { $0.isSelectedProductButton }
             .distinctUntilChanged()
             .bind(to: ResultVC.topView.productButton.rx.isSelected)
             .disposed(by: disposeBag)
         
+        // 브랜드 버튼 상태 변화
         reactor.state
             .map { $0.isSelectedBrandButton }
             .distinctUntilChanged()
             .bind(to: ResultVC.topView.brandButton.rx.isSelected )
             .disposed(by: disposeBag)
         
+        // 포스트 버튼 상태 변화
         reactor.state
             .map { $0.isSelectedPostButton }
             .distinctUntilChanged()
             .bind(to: ResultVC.topView.postButton.rx.isSelected)
             .disposed(by: disposeBag)
         
+        // Hepdia 버튼 상태 변화
         reactor.state
             .map { $0.isSelectedHpediaButton }
             .distinctUntilChanged()
             .bind(to: ResultVC.topView.hpediaButton.rx.isSelected )
             .disposed(by: disposeBag)
+        
     }
     
     // MARK: - Configure

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
@@ -73,6 +73,12 @@ extension SearchViewController {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        // keywordVC - viewDidLoad
+        keywordVC.rx.viewDidLoad
+            .map { Reactor.Action.keywordViewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: - State
         
         // 이전 뷰 컨트롤러로 이동
@@ -100,6 +106,14 @@ extension SearchViewController {
             .filter { $0 }
             .map { _ in }
             .bind(onNext: { self.changeViewController(self.ResultVC) })
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.keywords }
+            .distinctUntilChanged()
+            .bind(onNext: {
+                self.keywordVC.keywordList.addTags($0)
+            })
             .disposed(by: disposeBag)
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/Product.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/Product.swift
@@ -1,0 +1,15 @@
+//
+//  Product.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/02.
+//
+
+import Foundation
+import UIKit
+
+struct Product: Equatable {
+    var image: UIImage
+    var title: String
+    var content: String
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchBarContainerView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchBarContainerView.swift
@@ -1,0 +1,28 @@
+//
+//  SearchBarContainerView.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/02/27.
+//
+
+import UIKit
+
+class SearchBarContainerView: UIView {
+    
+    let searchBar: UISearchBar
+    
+    init(customSearchBar: UISearchBar) {
+        searchBar = customSearchBar
+        super.init(frame: .zero)
+        addSubview(searchBar)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        searchBar.frame = frame
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchListTableViewCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchListTableViewCell.swift
@@ -1,0 +1,46 @@
+//
+//  SearchListTableViewCell.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/02/28.
+//
+
+import UIKit
+
+class SearchListTableViewCell: UITableViewCell {
+
+    // MARK: - identifier
+    static let identifier = "SearchListTableViewCell"
+    
+    // MARK: - UI Component
+    
+    var titleLabel = UILabel().then {
+        $0.font = .customFont(.pretendard_light, 14)
+    }
+    
+    // MARK: - Layout
+    
+    override func layoutSubviews() {
+        configureUI()
+    }
+}
+
+extension SearchListTableViewCell {
+    
+    // MARK: - Configure
+    
+    func configureUI() {
+        
+        addSubview(titleLabel)
+        
+        titleLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(16)
+            $0.height.equalTo(34)
+        }
+    }
+    
+    func updateCell(_ title: String) {
+        self.titleLabel.text = title
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchResultCollectionViewCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchResultCollectionViewCell.swift
@@ -1,0 +1,81 @@
+//
+//  SearchResultCollectionViewCell.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/02.
+//
+
+import UIKit
+
+class SearchResultCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: - identifier
+    
+    static let identifier = "SearchResultCollectionViewCell"
+    
+    // MARK: - UI Component
+    
+    lazy var productImageView = UIImageView().then {
+        $0.backgroundColor = .customColor(.gray3)
+    }
+    
+    var titleLabel = UILabel().then {
+        $0.font = .customFont(.pretendard_medium, 14)
+    }
+    
+    var contentLabel = UILabel().then {
+        $0.numberOfLines = 2
+        $0.font = .customFont(.pretendard, 12)
+    }
+    
+    lazy var likeButton = UIButton().then {
+        $0.makeLikeButton()
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension SearchResultCollectionViewCell {
+    
+    func configureUI() {
+        [   productImageView,
+            titleLabel,
+            contentLabel,
+            likeButton
+        ]   .forEach { addSubview($0) }
+        
+        
+        productImageView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(productImageView.snp.width)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(productImageView.snp.bottom).offset(12)
+            $0.leading.equalToSuperview()
+        }
+        
+        contentLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(6)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        likeButton.snp.makeConstraints {
+            $0.top.equalTo(titleLabel)
+            $0.trailing.equalToSuperview()
+        }
+    }
+    
+    func updateCell(_ product: Product) {
+//        self.productImageView.image = product.image
+        self.titleLabel.text = product.title
+        self.contentLabel.text = product.content
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchResultTopView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchResultTopView.swift
@@ -1,0 +1,78 @@
+//
+//  SearchResultTopView.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/02.
+//
+
+import UIKit
+
+class SearchResultTopView: UIView {
+    
+    // MARK: - UI Component
+    
+    lazy var productButton = UIButton().then {
+        $0.makeCategoryButton("상품")
+    }
+    
+    lazy var brandButton = UIButton().then {
+        $0.makeCategoryButton("브랜드")
+    }
+    
+    lazy var postButton = UIButton().then {
+        $0.makeCategoryButton("포스트")
+    }
+    
+    lazy var hpediaButton = UIButton().then {
+        $0.makeCategoryButton("Hpedia")
+    }
+    
+    
+    // MARK: - init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configreUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension SearchResultTopView {
+    
+    // MARK: - Configure
+    
+    func configreUI() {
+        [   productButton,
+            brandButton,
+            postButton,
+            hpediaButton
+        ]   .forEach { addSubview($0) }
+        
+        productButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(14)
+            $0.leading.equalToSuperview().inset(16)
+            $0.height.equalTo(22)
+        }
+        
+        brandButton.snp.makeConstraints {
+            $0.top.equalTo(productButton)
+            $0.leading.equalTo(productButton.snp.trailing).offset(8)
+            $0.height.equalTo(22)
+        }
+        
+        postButton.snp.makeConstraints {
+            $0.top.equalTo(productButton)
+            $0.leading.equalTo(brandButton.snp.trailing).offset(8)
+            $0.height.equalTo(22)
+        }
+        
+        hpediaButton.snp.makeConstraints {
+            $0.top.equalTo(productButton)
+            $0.leading.equalTo(postButton.snp.trailing).offset(8)
+            $0.height.equalTo(22)
+        }
+    }
+}


### PR DESCRIPTION
### 이슈 번호
#18 

### 구현/추가 사항
- 검색 NavigationBar 높이 수정했습니다.
- 검색 전 -> SearchKeywordViewController
- 검색 중 -> SearchListViewController
- 검색 후 -> SearchResultViewController
- 해당 뷰 컨트롤러들을 SearchViewController에 자식으로 할당해 SearchBar의 TextField의 상태에 따라 보여지도록 구현했습니다.
- 기능 구현은 다음 이슈에 하겠습니다.