### PR TITLE
[Feat] 검색 페이지 기능 구현

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
@@ -12,7 +12,7 @@ class SearchReactor: Reactor {
     
     enum Action {
         case didTapBackButton
-        case didChangeTextField
+        case didChangeTextField(String)
         case didEndTextField
         case didTapProductButton
         case didTapBrandButton
@@ -28,6 +28,7 @@ class SearchReactor: Reactor {
         case isChangeToDefaultVC(Int?)
         case setKeyword([String])
         case setList([String])
+        case setContent(String)
         case setResultProduct([Product])
         case setProductButtonState(Bool)
         case setBrandButtonState(Bool)
@@ -36,7 +37,7 @@ class SearchReactor: Reactor {
     }
     
     struct State {
-        var Content: String = ""
+        var content: String = "" // textField에 입력된 값
         var isPopVC: Bool = false
         var isChangeTextField: Bool = false
         var isEndTextField: Bool = false
@@ -60,10 +61,10 @@ class SearchReactor: Reactor {
                 .just(.isPopVC(true)),
                 .just(.isPopVC(false))
             ])
-        case .didChangeTextField:
+        case .didChangeTextField(let inputContent):
             return .concat([
                 .just(.isChangeToListVC(true, 2)),
-                reqeustList(),
+                reqeustList(inputContent),
                 .just(.isChangeToListVC(false, nil))
             ])
         case .didEndTextField:
@@ -100,6 +101,8 @@ class SearchReactor: Reactor {
             state.keywords = keywords
         case .setList(let lists):
             state.lists = lists
+        case .setContent(let inputContent):
+            state.content = inputContent
         case .setResultProduct(let products):
             state.resultProduct = products
         case .isPopVC(let isPop):
@@ -161,10 +164,10 @@ class SearchReactor: Reactor {
 
 extension SearchReactor {
     
-    func reqeustList() -> Observable<Mutation> {
+    func reqeustList(_ inputContent: String) -> Observable<Mutation> {
         
-        // TODO: - 서버 통신해서 검색어 받아오기
-        
+        // TODO: - inputContent값으로 서버 통신해서 검색어 받아오기
+                
         let data =  ["랑방 모던 프린세스",
                      "랑방 블루 오키드",
                      "랑방 워터 릴리",
@@ -176,7 +179,10 @@ extension SearchReactor {
                      "랑방 워터 릴리",
                      "랑방 잔느"]
         
-        return .just(.setList(data))
+        return .concat([
+            .just(.setList(data)),
+            .just(.setContent(inputContent))
+        ])
     }
     
     func requestResult() -> Observable<Mutation> {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
@@ -18,6 +18,7 @@ class SearchReactor: Reactor {
         case didTapBrandButton
         case didTapPostButton
         case didTapHpediaButton
+        case didTapSearchListCell(IndexPath)
         case didClearTextField
     }
     
@@ -89,6 +90,13 @@ class SearchReactor: Reactor {
 
         case .didTapHpediaButton:
             return .just(.setHpediaButtonState(true))
+            
+        case .didTapSearchListCell(let indexPath):
+            return .concat([
+                .just(.isChangeToResultVC(true, 3)),
+                requestResult(currentState.lists[indexPath.item]),
+                .just(.isChangeToResultVC(false, nil))
+            ])
         }
     }
     
@@ -166,7 +174,8 @@ extension SearchReactor {
     func reqeustList(_ content: String) -> Observable<Mutation> {
         
         // TODO: - content값으로 서버 통신해서 검색어 받아오기
-                
+        print("입력한 값:", content)
+
         let data =  ["랑방 모던 프린세스",
                      "랑방 블루 오키드",
                      "랑방 워터 릴리",
@@ -187,6 +196,7 @@ extension SearchReactor {
     func requestResult(_ content: String) -> Observable<Mutation> {
         
         // TODO: - 입력받은 content값으로 서버 통신해서 결과값 받아오기
+        print("검색하는 값:", content)
         
         let data: [Product] = [Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛")]
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
@@ -27,7 +27,7 @@ class SearchReactor: Reactor {
         case isChangeToResultVC(Bool, Int?)
         case isChangeToListVC(Bool, Int?)
         case isChangeToDefaultVC(Int?)
-        case isTapSearchListCell(String?)
+        case isTapSearchListCell(String)
         case setKeyword([String])
         case setList([String])
         case setContent(String)
@@ -99,7 +99,7 @@ class SearchReactor: Reactor {
                 .just(.isTapSearchListCell(currentState.lists[indexPath.item])),
                 requestResult(currentState.lists[indexPath.item]),
                 .just(.isChangeToResultVC(false, nil)),
-                .just(.isTapSearchListCell(nil))
+                .just(.isTapSearchListCell(""))
             ])
         }
     }
@@ -169,9 +169,7 @@ class SearchReactor: Reactor {
             state.isSelectedProductButton = false
             
         case .isTapSearchListCell(let content):
-            if let content = content {
-                state.listContent = content
-            }
+            state.listContent = content
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
@@ -19,6 +19,7 @@ class SearchReactor: Reactor {
         case didTapPostButton
         case didTapHpediaButton
         case didTapSearchListCell(IndexPath)
+        case didTapSearchResultCell(IndexPath)
         case didClearTextField
     }
     
@@ -31,11 +32,12 @@ class SearchReactor: Reactor {
         case setKeyword([String])
         case setList([String])
         case setContent(String)
-        case setResultProduct([Product])
+        case setResultProduct([Perfume])
         case setProductButtonState(Bool)
         case setBrandButtonState(Bool)
         case setPostButtonState(Bool)
         case setHpediaButtonState(Bool)
+        case setSelectedPerfumeId(Int?)
     }
     
     struct State {
@@ -46,13 +48,14 @@ class SearchReactor: Reactor {
         var isEndTextField: Bool = false
         var keywords: [String] = []
         var lists: [String] = [] // 연관 검색어 리스트
-        var resultProduct: [Product] = []
+        var resultProduct: [Perfume] = []
         var nowPage: Int = 1 // 현재 보여지고 있는 페이지
         var prePage: Int = 0 // 이전 페이지
         var isSelectedProductButton: Bool = true
         var isSelectedBrandButton: Bool = false
         var isSelectedPostButton: Bool = false
         var isSelectedHpediaButton: Bool = false
+        var selectedPerfumeId: Int? = nil
     }
     
     var initialState = State()
@@ -100,6 +103,12 @@ class SearchReactor: Reactor {
                 requestResult(currentState.lists[indexPath.item]),
                 .just(.isChangeToResultVC(false, nil)),
                 .just(.isTapSearchListCell(""))
+            ])
+            
+        case .didTapSearchResultCell(let indexPath):
+            return .concat([
+                .just(.setSelectedPerfumeId(currentState.resultProduct[indexPath.item].perfumeId)),
+                .just(.setSelectedPerfumeId(nil))
             ])
         }
     }
@@ -170,6 +179,9 @@ class SearchReactor: Reactor {
             
         case .isTapSearchListCell(let content):
             state.listContent = content
+            
+        case .setSelectedPerfumeId(let perfumeId):
+            state.selectedPerfumeId = perfumeId
         }
         
         return state
@@ -205,7 +217,19 @@ extension SearchReactor {
         // TODO: - 입력받은 content값으로 서버 통신해서 결과값 받아오기
         print("검색하는 값:", content)
         
-        let data: [Product] = [Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛")]
+        let data: [Perfume] = [
+            Perfume(perfumeId: 1, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 2, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 3, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 4, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 5, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 6, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 7, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 8, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 9, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 10, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 11, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!),
+            Perfume(perfumeId: 12, titleName: "랑방", content: "랑방 모던프린세스 블루밍 오 드 뚜왈렛", image: UIImage(named: "jomalon")!)]
         
         return .just(.setResultProduct(data))
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
@@ -27,6 +27,7 @@ class SearchReactor: Reactor {
         case isChangeToResultVC(Bool, Int?)
         case isChangeToListVC(Bool, Int?)
         case isChangeToDefaultVC(Int?)
+        case isTapSearchListCell(String?)
         case setKeyword([String])
         case setList([String])
         case setContent(String)
@@ -39,6 +40,7 @@ class SearchReactor: Reactor {
     
     struct State {
         var content: String = "" // textField에 입력된 값
+        var listContent: String = "" // 연관 검색어 List 클릭한 값
         var isPopVC: Bool = false
         var isChangeTextField: Bool = false
         var isEndTextField: Bool = false
@@ -94,8 +96,10 @@ class SearchReactor: Reactor {
         case .didTapSearchListCell(let indexPath):
             return .concat([
                 .just(.isChangeToResultVC(true, 3)),
+                .just(.isTapSearchListCell(currentState.lists[indexPath.item])),
                 requestResult(currentState.lists[indexPath.item]),
-                .just(.isChangeToResultVC(false, nil))
+                .just(.isChangeToResultVC(false, nil)),
+                .just(.isTapSearchListCell(nil))
             ])
         }
     }
@@ -163,6 +167,11 @@ class SearchReactor: Reactor {
             state.isSelectedBrandButton = false
             state.isSelectedPostButton = false
             state.isSelectedProductButton = false
+            
+        case .isTapSearchListCell(let content):
+            if let content = content {
+                state.listContent = content
+            }
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/Reactor/SearchReactor.swift
@@ -61,16 +61,16 @@ class SearchReactor: Reactor {
                 .just(.isPopVC(true)),
                 .just(.isPopVC(false))
             ])
-        case .didChangeTextField(let inputContent):
+        case .didChangeTextField(let content):
             return .concat([
                 .just(.isChangeToListVC(true, 2)),
-                reqeustList(inputContent),
+                reqeustList(content),
                 .just(.isChangeToListVC(false, nil))
             ])
         case .didEndTextField:
             return .concat([
                 .just(.isChangeToResultVC(true, 3)),
-                requestResult(),
+                requestResult(currentState.content),
                 .just(.isChangeToResultVC(false, nil))
             ])
         case .didClearTextField:
@@ -89,7 +89,6 @@ class SearchReactor: Reactor {
 
         case .didTapHpediaButton:
             return .just(.setHpediaButtonState(true))
-        
         }
     }
     
@@ -164,9 +163,9 @@ class SearchReactor: Reactor {
 
 extension SearchReactor {
     
-    func reqeustList(_ inputContent: String) -> Observable<Mutation> {
+    func reqeustList(_ content: String) -> Observable<Mutation> {
         
-        // TODO: - inputContent값으로 서버 통신해서 검색어 받아오기
+        // TODO: - content값으로 서버 통신해서 검색어 받아오기
                 
         let data =  ["랑방 모던 프린세스",
                      "랑방 블루 오키드",
@@ -181,11 +180,13 @@ extension SearchReactor {
         
         return .concat([
             .just(.setList(data)),
-            .just(.setContent(inputContent))
+            .just(.setContent(content))
         ])
     }
     
-    func requestResult() -> Observable<Mutation> {
+    func requestResult(_ content: String) -> Observable<Mutation> {
+        
+        // TODO: - 입력받은 content값으로 서버 통신해서 결과값 받아오기
         
         let data: [Product] = [Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛"), Product(image: UIImage(named: "jomalon")!, title: "랑방", content: "랑방 모던프린세스 불루밍 오 드 뚜왈렛")]
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchListViewController.swift
@@ -19,7 +19,6 @@ class SearchListViewController: UIViewController {
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         configureUI()
     }
 }
@@ -31,9 +30,7 @@ extension SearchListViewController {
     func configureUI() {
         
         view.addSubview(tableView)
-        
-        tableView.delegate = self
-        
+                
         tableView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(26)
             $0.leading.trailing.bottom.equalToSuperview()
@@ -41,9 +38,3 @@ extension SearchListViewController {
     }
 }
 
-extension SearchListViewController: UITableViewDelegate {
-
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 34
-    }
-}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchResultViewController.swift
@@ -30,8 +30,6 @@ extension SearchResultViewController {
     
     // MARK: - Configure
     func configureUI() {
-
-        collectionView.delegate = self
         
         [   topView,
             collectionView
@@ -46,19 +44,5 @@ extension SearchResultViewController {
             $0.top.equalTo(topView.snp.bottom).offset(3)
             $0.leading.trailing.bottom.equalToSuperview()
         }
-    }
-}
-
-extension SearchResultViewController: UICollectionViewDelegateFlowLayout {
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        
-        let width = (UIScreen.main.bounds.width - 40) / 2
-        let height = width + 82
-        return CGSize(width: width, height: height)
-    }
-
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
@@ -208,10 +208,9 @@ extension SearchViewController {
         reactor.state
             .map { $0.listContent }
             .distinctUntilChanged()
+            .filter { $0 != "" }
             .bind(to: searchBar.rx.text)
             .disposed(by: disposeBag)
-        
-        
     }
     
     // MARK: - Configure

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
@@ -104,6 +104,12 @@ extension SearchViewController {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        // 연관 검색어 List Cell 클릭
+        listVC.tableView.rx.itemSelected
+            .map { Reactor.Action.didTapSearchListCell($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: - State
         
         // 이전 뷰 컨트롤러로 이동
@@ -205,6 +211,9 @@ extension SearchViewController {
         
         view.backgroundColor = .white
         
+        listVC.tableView.rx.setDelegate(self)
+            .disposed(by: disposeBag)
+        
         [   listVC,
             ResultVC
         ]   .forEach {  self.addChild($0)   }
@@ -250,5 +259,12 @@ extension SearchViewController {
         vc.willMove(toParent: self)
         vc.removeFromParent()
         vc.view.removeFromSuperview()
+    }
+}
+
+extension SearchViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 34
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
@@ -204,6 +204,14 @@ extension SearchViewController {
             .bind(to: ResultVC.topView.hpediaButton.rx.isSelected )
             .disposed(by: disposeBag)
         
+        // 연관 검색어를 클릭하면 해당 값을 searchBar의 text에 바인딩
+        reactor.state
+            .map { $0.listContent }
+            .distinctUntilChanged()
+            .bind(to: searchBar.rx.text)
+            .disposed(by: disposeBag)
+        
+        
     }
     
     // MARK: - Configure

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
@@ -62,8 +62,7 @@ extension SearchViewController {
         // Text 입력
         searchBar.rx.text.orEmpty
             .distinctUntilChanged()
-            .filter { $0 != "" }
-            .map { _ in Reactor.Action.didChangeTextField }
+            .map { Reactor.Action.didChangeTextField($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchResultCollectionViewCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchResultCollectionViewCell.swift
@@ -74,9 +74,9 @@ extension SearchResultCollectionViewCell {
         }
     }
     
-    func updateCell(_ product: Product) {
+    func updateCell(_ product: Perfume) {
 //        self.productImageView.image = product.image
-        self.titleLabel.text = product.title
+        self.titleLabel.text = product.titleName
         self.contentLabel.text = product.content
     }
 }


### PR DESCRIPTION


https://user-images.githubusercontent.com/48830320/224361577-2c5a15a3-8033-4c85-a1f2-5164f04b32d8.mp4


### 이슈 번호
#28 

### 구현/추가 사항
- 아직 검색 결과 페이지의 카테고리 디자인이 향수밖에 없어서 검색 결과값을 Product에서 Perfume구조체로 바꿨습니다.
- 연관 검색어와 검색 결과, 검색 결과 Cell클릭시 데이터는 임시로 넣었습니다. 