### PR TITLE
[Feat] 댓글 정렬 기능 & 댓글 수정 기능 & 향수 하단 뷰 좋아요 기능 구현

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -39,9 +39,25 @@ extension UIViewController {
         self.navigationController?.pushViewController(commentDetailVC, animated: true)
     }
     
-    func presentCommentWriteViewController(_ id: Int) {
+    func presentCommentWriteViewController(_ perfumeId: Int) {
         let commentWriteVC = CommentWriteViewController()
-        commentWriteVC.reactor = CommentWriteReactor(id)
+        commentWriteVC.reactor = CommentWriteReactor(
+            currentPerfumeId: perfumeId,
+            isWrite: false)
+        
+        commentWriteVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(commentWriteVC, animated: true)
+    }
+    
+    func presentCommentWirteViewControllerForWriter(_ commentId: Int, _ comment: String) {
+        
+        let commentWriteVC = CommentWriteViewController()
+        commentWriteVC.reactor = CommentWriteReactor(
+            isWrite: true,
+            content: comment,
+            commentId: commentId
+        )
+        
         commentWriteVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(commentWriteVC, animated: true)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentDetail/Reactor/CommentDetailReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentDetail/Reactor/CommentDetailReactor.swift
@@ -16,14 +16,17 @@ class CommentDetailReactor: Reactor {
     
     enum Action {
         case didTapLikeButton
+        case didTapChangeButton
     }
     
     enum Mutation {
         case setCommentLike(Bool)
+        case setIsPresentChangeVC(Bool)
     }
     
     struct State {
         var comment: Comment
+        var isTapChangeButton: Bool = false
     }
     
     init(_ currentCommentId: Int) {
@@ -40,6 +43,12 @@ class CommentDetailReactor: Reactor {
             } else {
                 return .just(.setCommentLike(false))
             }
+            
+        case .didTapChangeButton:
+            return .concat([
+                .just(.setIsPresentChangeVC(true)),
+                .just(.setIsPresentChangeVC(false))
+            ])
         }
     }
     
@@ -50,6 +59,9 @@ class CommentDetailReactor: Reactor {
         case .setCommentLike(let isLike):
             state.comment.isLike = isLike
             state.comment.likeCount += isLike ? 1 : -1
+            
+        case .setIsPresentChangeVC(let isPresent):
+            state.isTapChangeButton = isPresent
         }
         
         return state
@@ -63,6 +75,6 @@ extension CommentDetailReactor {
         print(id)
         
         // TODO: currentCommentId로 서버와 통신
-        return Comment(commentId: 1, name: "안녕하세요", image: UIImage(named: "jomalon")!, likeCount: 150, content: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요", isLike: false)
+        return Comment(commentId: 1, name: "안녕하세요", image: UIImage(named: "jomalon")!, likeCount: 150, content: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요", isLike: false, isWrite: true)
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentDetail/ViewController/CommentDetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentDetail/ViewController/CommentDetailViewController.swift
@@ -60,11 +60,19 @@ class CommentDetailViewController: UIViewController, View {
         $0.backgroundColor = .customColor(.gray1)
     }
     
+    lazy var changeButton = UIButton().then {
+        $0.titleLabel?.font = .customFont(.pretendard, 16)
+        $0.setTitle("수정", for: .normal)
+        $0.setTitleColor(.black, for: .normal)
+        $0.tintColor = .black
+    }
+    
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setBackItemNaviBar("댓글")
         configureUI()
+        configureNavigationBar()
     }
 }
 
@@ -155,6 +163,12 @@ extension CommentDetailViewController {
             $0.height.equalTo(20)
         }
 
+    }
+    
+    func configureNavigationBar() {
+        let changeButtonItem = UIBarButtonItem(customView: changeButton)
+        
+        self.navigationItem.rightBarButtonItem = changeButtonItem
     }
     
     func setLikeButtonText(_ text: String) -> AttributedString {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentDetail/ViewController/CommentDetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentDetail/ViewController/CommentDetailViewController.swift
@@ -89,6 +89,12 @@ extension CommentDetailViewController {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        // 수정하기 버튼 클릭
+        changeButton.rx.tap
+            .map { Reactor.Action.didTapChangeButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: - State
         
         // 유저 이미지
@@ -121,6 +127,26 @@ extension CommentDetailViewController {
             .map { String($0) }
             .bind(onNext: {
                 self.commentLikeButton.configuration?.attributedTitle = self.setLikeButtonText($0)
+            })
+            .disposed(by: disposeBag)
+        
+        // 수정 버튼 상태
+        reactor.state
+            .map { $0.comment.isWrite }
+            .map { !$0 }
+            .bind(to: changeButton.rx.isHidden )
+            .disposed(by: disposeBag)
+        
+        // 수정 버튼 클릭 상태
+        reactor.state
+            .map { $0.isTapChangeButton }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in }
+            .bind(onNext: {
+                self.presentCommentWirteViewControllerForWriter(
+                    (self.reactor?.currentState.comment.commentId)!,
+                    (self.reactor?.currentState.comment.content)!)
             })
             .disposed(by: disposeBag)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentList/Reactor/CommentListReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentList/Reactor/CommentListReactor.swift
@@ -16,12 +16,15 @@ class CommentListReactor: Reactor {
         case viewWillAppear
         case didTapCell(IndexPath)
         case didTapWriteButton
+        case didTapLikeSortButton
+        case didTapRecentSortButton
     }
     
     enum Mutation {
         case setSelectedCommentId(IndexPath?)
         case setIsPresentCommentWrite(Int?)
         case setCommentData
+        case setSort(Int)
     }
     
     struct State {
@@ -54,6 +57,12 @@ class CommentListReactor: Reactor {
                 .just(.setIsPresentCommentWrite(currentPerfumeId)),
                 .just(.setIsPresentCommentWrite(nil))
             ])
+        
+        case .didTapLikeSortButton:
+            return .just(.setSort(1))
+            
+        case .didTapRecentSortButton:
+            return .just(.setSort(2))
         }
     }
     
@@ -74,35 +83,42 @@ class CommentListReactor: Reactor {
             state.isPresentCommentWriteVC = perfumeId
             
         case .setCommentData:
-            let data = CommentListReactor.setCommentsList(currentPerfumeId)
+            let data = CommentListReactor.setCommentsList(currentPerfumeId, 1)
             state.comments = data.0
             state.commentCount = data.1
             
+        case .setSort(let sortType):
+            let data = CommentListReactor.setCommentsList(currentPerfumeId, sortType)
+            state.comments = data.0
+            state.commentCount = data.1
         }
         return state
     }
 }
 
 extension CommentListReactor {
-    static func setCommentsList(_ id: Int) -> ([CommentSection], Int) {
+    static func setCommentsList(_ id: Int, _ sortType: Int) -> ([CommentSection], Int) {
         
         print(id)
-        // TODO: currentPerfumeId로 서버 통신해서 댓글 가져오기
+        // TODO: currentPerfumeId와 sortType으로 서버 통신해서 댓글 가져오기
         
-        let comments = [
-            Comment(commentId: 1, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false),
-            Comment(commentId: 2, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false),
-            Comment(commentId: 3, name: "test", image: UIImage(named: "jomalon")!, likeCount: 0, content: "test", isLike: false),
-            Comment(commentId: 4, name: "test", image: UIImage(named: "jomalon")!, likeCount: 0, content: "test", isLike: false),
-            Comment(commentId: 5, name: "test", image: UIImage(named: "jomalon")!, likeCount: 0, content: "test", isLike: false),
-            Comment(commentId: 6, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false),
-            Comment(commentId: 7, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false),
-            Comment(commentId: 8, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false),
-            Comment(commentId: 9, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false),
-            Comment(commentId: 10, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false),
-            Comment(commentId: 11, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false),
-            Comment(commentId: 12, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false)
+        var comments = [
+            Comment(commentId: 1, name: "test", image: UIImage(named: "jomalon")!, likeCount: 124, content: "1", isLike: false),
+            Comment(commentId: 2, name: "test", image: UIImage(named: "jomalon")!, likeCount: 5123, content: "2", isLike: false),
+            Comment(commentId: 3, name: "test", image: UIImage(named: "jomalon")!, likeCount: 10, content: "3", isLike: false),
+            Comment(commentId: 4, name: "test", image: UIImage(named: "jomalon")!, likeCount: 23, content: "4", isLike: false),
+            Comment(commentId: 5, name: "test", image: UIImage(named: "jomalon")!, likeCount: 20, content: "5", isLike: false),
+            Comment(commentId: 6, name: "test", image: UIImage(named: "jomalon")!, likeCount: 2341, content: "6", isLike: false),
+            Comment(commentId: 7, name: "test", image: UIImage(named: "jomalon")!, likeCount: 122, content: "7", isLike: false),
+            Comment(commentId: 8, name: "test", image: UIImage(named: "jomalon")!, likeCount: 341, content: "8", isLike: false),
+            Comment(commentId: 9, name: "test", image: UIImage(named: "jomalon")!, likeCount: 55, content: "9", isLike: false),
+            Comment(commentId: 10, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "10", isLike: false),
+            Comment(commentId: 11, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "11", isLike: false),
+            Comment(commentId: 12, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "12", isLike: false)
         ]
+        
+        sortType == 1 ? comments.sort { $0.likeCount > $1.likeCount }: comments.sort { $0.commentId < $1.commentId }
+        
         
         let commentItems = comments.map {CommentSectionItem.commentCell(CommentCellReactor(comment: $0), $0.commentId)}
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentList/Reactor/CommentListReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentList/Reactor/CommentListReactor.swift
@@ -103,18 +103,18 @@ extension CommentListReactor {
         // TODO: currentPerfumeId와 sortType으로 서버 통신해서 댓글 가져오기
         
         var comments = [
-            Comment(commentId: 1, name: "test", image: UIImage(named: "jomalon")!, likeCount: 124, content: "1", isLike: false),
-            Comment(commentId: 2, name: "test", image: UIImage(named: "jomalon")!, likeCount: 5123, content: "2", isLike: false),
-            Comment(commentId: 3, name: "test", image: UIImage(named: "jomalon")!, likeCount: 10, content: "3", isLike: false),
-            Comment(commentId: 4, name: "test", image: UIImage(named: "jomalon")!, likeCount: 23, content: "4", isLike: false),
-            Comment(commentId: 5, name: "test", image: UIImage(named: "jomalon")!, likeCount: 20, content: "5", isLike: false),
-            Comment(commentId: 6, name: "test", image: UIImage(named: "jomalon")!, likeCount: 2341, content: "6", isLike: false),
-            Comment(commentId: 7, name: "test", image: UIImage(named: "jomalon")!, likeCount: 122, content: "7", isLike: false),
-            Comment(commentId: 8, name: "test", image: UIImage(named: "jomalon")!, likeCount: 341, content: "8", isLike: false),
-            Comment(commentId: 9, name: "test", image: UIImage(named: "jomalon")!, likeCount: 55, content: "9", isLike: false),
-            Comment(commentId: 10, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "10", isLike: false),
-            Comment(commentId: 11, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "11", isLike: false),
-            Comment(commentId: 12, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "12", isLike: false)
+            Comment(commentId: 1, name: "test", image: UIImage(named: "jomalon")!, likeCount: 124, content: "1", isLike: false, isWrite: false),
+            Comment(commentId: 2, name: "test", image: UIImage(named: "jomalon")!, likeCount: 5123, content: "2", isLike: false, isWrite: false),
+            Comment(commentId: 3, name: "test", image: UIImage(named: "jomalon")!, likeCount: 10, content: "3", isLike: false, isWrite: false),
+            Comment(commentId: 4, name: "test", image: UIImage(named: "jomalon")!, likeCount: 23, content: "4", isLike: false, isWrite: false),
+            Comment(commentId: 5, name: "test", image: UIImage(named: "jomalon")!, likeCount: 20, content: "5", isLike: false, isWrite: false),
+            Comment(commentId: 6, name: "test", image: UIImage(named: "jomalon")!, likeCount: 2341, content: "6", isLike: false, isWrite: false),
+            Comment(commentId: 7, name: "test", image: UIImage(named: "jomalon")!, likeCount: 122, content: "7", isLike: false, isWrite: false),
+            Comment(commentId: 8, name: "test", image: UIImage(named: "jomalon")!, likeCount: 341, content: "8", isLike: false, isWrite: false),
+            Comment(commentId: 9, name: "test", image: UIImage(named: "jomalon")!, likeCount: 55, content: "9", isLike: false, isWrite: false),
+            Comment(commentId: 10, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "10", isLike: false, isWrite: false),
+            Comment(commentId: 11, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "11", isLike: false, isWrite: false),
+            Comment(commentId: 12, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "12", isLike: false, isWrite: false)
         ]
         
         sortType == 1 ? comments.sort { $0.likeCount > $1.likeCount }: comments.sort { $0.commentId < $1.commentId }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentList/ViewController/CommentListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentList/ViewController/CommentListViewController.swift
@@ -28,6 +28,7 @@ class CommentListViewController: UIViewController, View {
     let bottomView = CommentListBottomView()
     
     lazy var layout = UICollectionViewFlowLayout()
+    private var header: CommentListTopView!
     
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout).then {
         $0.alwaysBounceVertical = true
@@ -104,6 +105,26 @@ extension CommentListViewController {
             .disposed(by: disposeBag)
     }
     
+    func bindHeader() {
+                
+        // MARK: - bindHeader - Action
+        
+        // 좋아요순 버튼 클릭
+        header.likeSortButton.rx.tap
+            .do(onNext: { print("좋아요순")})
+            .map { Reactor.Action.didTapLikeSortButton }
+            .bind(to: commendReactor.action)
+            .disposed(by: disposeBag)
+        
+        // 최신순 버튼 클릭
+        header.recentSortButton.rx.tap
+            .do(onNext: { print("최신순")})
+            .map { Reactor.Action.didTapRecentSortButton }
+            .bind(to: commendReactor.action)
+            .disposed(by: disposeBag)
+        
+    }
+    
     func configureCollectionViewDataSource() {
         
         dataSource = RxCollectionViewSectionedReloadDataSource<CommentSection>(configureCell: { _, collectionView, indexPath, item -> UICollectionViewCell in
@@ -120,6 +141,9 @@ extension CommentListViewController {
             switch indexPath.section {
             case 0:
                 guard let commentListTopView = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: CommentListTopView.identifier, for: indexPath) as? CommentListTopView else { return UICollectionReusableView() }
+                
+                self.header = commentListTopView
+                self.bindHeader()
                 
                 return commentListTopView
                 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentWrite/Reactor/CommentWriteReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentWrite/Reactor/CommentWriteReactor.swift
@@ -10,31 +10,37 @@ import RxSwift
 
 class CommentWriteReactor: Reactor {
     var initialState: State
-    var currentPerfumeId: Int
     
     enum Action {
         case didTapOkButton
         case didTapCancleButton
-        case didBeginTextViewEditing
+        case didBeginTextViewEditing(String)
         case didEndTextViewEditing
     }
     
     enum Mutation {
-        case setIsBeginEditing(Bool)
         case setIsEndEditing(Bool)
         case setIsPopVC(Bool)
+        case setContent(String)
     }
     
     struct State {
-        var content: String
+        var content: String = "해당 제품에 대한 의견을 남겨주세요"
+        var isWrite: Bool = false // 수정 or 새로 작성 상태
+        var commentId: Int? = nil
+        var perfumeId: Int? = nil
         var isPopVC: Bool = false
         var isBeginEditing: Bool = false
         var isEndEditing: Bool = false
     }
     
-    init(_ currentPerfumeId: Int) {
-        self.currentPerfumeId = currentPerfumeId
-        self.initialState = State(content: "")
+    init(currentPerfumeId: Int = 0, isWrite: Bool, content: String = "", commentId: Int = 0) {        
+        // 수정인 경우
+        if isWrite {
+            self.initialState = State(content: content, isWrite: isWrite, commentId: commentId)
+        } else { // 새로 댓글을 다는 경우
+            self.initialState = State()
+        }
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -49,11 +55,15 @@ class CommentWriteReactor: Reactor {
                 .just(.setIsPopVC(true)),
                 .just(.setIsPopVC(false))
             ])
-        case .didBeginTextViewEditing:
-            return .concat([
-                .just(.setIsBeginEditing(true)),
-                .just(.setIsBeginEditing(false))
-            ])
+        case .didBeginTextViewEditing(let content):
+            
+            var nowContent = content
+            
+            if nowContent == "해당 제품에 대한 의견을 남겨주세요" {
+                nowContent = ""
+            }
+            
+            return .just(.setContent(nowContent))
         
         case .didEndTextViewEditing:
             return .concat([
@@ -69,12 +79,14 @@ class CommentWriteReactor: Reactor {
         switch mutation {
         case .setIsPopVC(let isPop):
             state.isPopVC = isPop
-        case .setIsBeginEditing(let isEditing):
-            state.isBeginEditing = isEditing
         case .setIsEndEditing(let isEnd):
             state.isEndEditing = isEnd
+        case .setContent(let content):
+            state.content = content
         }
         
         return state
     }
+    
+    // TODO: 수정 상태 or 작성 상태에 따라서 서버로 댓글 전달하기
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentWrite/ViewController/CommentWriteViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/CommentWrite/ViewController/CommentWriteViewController.swift
@@ -42,8 +42,6 @@ class CommentWriteViewController: UIViewController, View {
     
     lazy var textView = UITextView().then {
         $0.font = .customFont(.pretendard, 14)
-        $0.text = "해당 제품에 대한 의견을 남겨주세요"
-        $0.textColor = .customColor(.gray3)
         $0.textAlignment = .left
     }
 
@@ -76,9 +74,9 @@ extension CommentWriteViewController {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        // textView 사용자가 입력 시작
+        // textView 사용자가 입력 시작 -> Action으로 전달한 textView.text값에 따라서 Reactor의 Content값 바꿈
         textView.rx.didBeginEditing
-            .map { Reactor.Action.didBeginTextViewEditing }
+            .map { Reactor.Action.didBeginTextViewEditing(self.textView.text) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
@@ -99,19 +97,6 @@ extension CommentWriteViewController {
             .bind(onNext: self.popViewController)
             .disposed(by: disposeBag)
         
-        // 사용자 입력 시작
-        reactor.state
-            .map { $0.isBeginEditing }
-            .distinctUntilChanged()
-            .filter { $0 }
-            .map { _ in }
-            .bind(onNext: {
-                if self.textView.text == "해당 제품에 대한 의견을 남겨주세요" {
-                    self.textView.text = nil
-                    self.textView.textColor = .black
-                }
-            })
-            .disposed(by: disposeBag)
         
         // 사용자가 입력 종료 (textView 비활성화)
         reactor.state
@@ -124,6 +109,17 @@ extension CommentWriteViewController {
                     self.textView.text = "해당 제품에 대한 의견을 남겨주세요"
                     self.textView.textColor = .customColor(.gray3)
                 }
+            })
+            .disposed(by: disposeBag)
+        
+        // 댓글 내용에 따른 색상 변화
+        reactor.state
+            .map { $0.content }
+            .bind(onNext: {
+                self.textView.textColor =
+                $0 == "해당 제품에 대한 의견을 남겨주세요" ? .customColor(.gray3) : .black
+                
+                self.textView.text = $0
             })
             .disposed(by: disposeBag)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/Model/Comment.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/Model/Comment.swift
@@ -14,4 +14,5 @@ struct Comment {
     var likeCount: Int
     var content: String
     var isLike: Bool
+    var isWrite: Bool
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/Reactor/DetailViewReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/Reactor/DetailViewReactor.swift
@@ -147,7 +147,7 @@ extension DetailViewReactor {
             topTasting: "test",
             heartTasting: "test",
             baseTasting: "test",
-            isLikePerfume: false,
+            isLikePerfume: true,
             isLikeBrand: false
         )
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/Reactor/DetailViewReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/Reactor/DetailViewReactor.swift
@@ -152,9 +152,9 @@ extension DetailViewReactor {
         )
         
         let commentItems = [
-            Comment(commentId: 1, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false),
-            Comment(commentId: 2, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false),
-            Comment(commentId: 3, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false)
+            Comment(commentId: 1, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false, isWrite: false),
+            Comment(commentId: 2, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false, isWrite: false),
+            Comment(commentId: 3, name: "test", image: UIImage(named: "jomalon")!, likeCount: 100, content: "test", isLike: false, isWrite: false)
         ]
         
         let recommendItems = [

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/View/DetailBottomView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/View/DetailBottomView.swift
@@ -14,7 +14,12 @@ class DetailBottomView: UIView {
     // MARK: Properties
 
     lazy var likeButton = UIButton().then {
-        $0.setImage(UIImage(named: "bottomHeart"), for: .normal)
+        let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular, scale: .default)
+        let normalImage = UIImage(named: "bottomHeart", in: .none, with: config)
+        let selectedImage = UIImage(named: "bottomHeart", in: .none, with: config)?.withTintColor(.red)
+
+        $0.setImage(normalImage, for: .normal)
+        $0.setImage(selectedImage, for: .selected)
     }
 
     lazy var shareButton = UIButton().then {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/ViewController/DetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Detail/ViewController/DetailViewController.swift
@@ -165,6 +165,19 @@ extension DetailViewController {
                 
                 perfumeInfoCell.reactor = reactor
                 
+                // 하단 뷰 향수 좋아요 버튼 클릭시 액션 전달
+                self.bottomView.likeButton.rx.tap
+                    .map { _ in .didTapPerfumeLikeButton }
+                    .bind(to: perfumeInfoCell.reactor!.action)
+                    .disposed(by: self.disposeBag)
+                
+                // perfumeInfoReactor의 향수 좋아요 상태 변화
+                perfumeInfoCell.reactor?.state
+                    .map { $0.isLikePerfume }
+                    .distinctUntilChanged()
+                    .bind(to: self.bottomView.likeButton.rx.isSelected)
+                    .disposed(by: self.disposeBag)
+                
                 return perfumeInfoCell
             case .commentCell(let reactor, _):
                 guard let commentCell = collectionView.dequeueReusableCell(withReuseIdentifier: CommentCell.identifier, for: indexPath) as? CommentCell else { return UICollectionViewCell() }


### PR DESCRIPTION


https://user-images.githubusercontent.com/48830320/224551820-756a987f-1b13-4e76-9ff6-7a0927e5e649.mp4



### 이슈번호
#30 

### 구현/추가사항
- 댓글 정렬 기능은 일단은 내부에서 정렬해서 구현했는데 서버로 정렬타입을 보내서 해야할지 아니면 클라이언트내에서 해야할지 회의해야 될 것 같습니다.
- 향수 상세보기 화면에서 하단 뷰에 있는 좋아요 버튼 기능 구현했는데 좋아요 눌렀을 때 이미지가 아직 없어서 tintColor임시로 빨간색으로 지정했습니다.
- 댓글 자세히보기 페이지에서 확인 버튼 눌렀을 때 기능은 아직 API가 없어서 놧뒀습니다! 추후에 수정인지 아닌지에 따라서 분기처리로 API 통신하도록 하겠습니다.