### PR TITLE
[Feat] 브랜드 검색 페이지 UI 구현 

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		2C4041D229ACDC58009247E7 /* SearchListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041D129ACDC58009247E7 /* SearchListViewController.swift */; };
 		2C4041D429ACDC67009247E7 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041D329ACDC67009247E7 /* SearchResultViewController.swift */; };
 		2C4041D629AD1211009247E7 /* SearchListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041D529AD1211009247E7 /* SearchListTableViewCell.swift */; };
+		2C4A266629C320B5009F288F /* BrandSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4A266529C320B5009F288F /* BrandSearchViewController.swift */; };
 		2C4DD36C29754B3A0027CE40 /* HomeTopCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36B29754B3A0027CE40 /* HomeTopCell.swift */; };
 		2C4DD36E29754B410027CE40 /* HomeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36D29754B410027CE40 /* HomeCell.swift */; };
 		2C4DD37029756D3A0027CE40 /* HomeCellHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36F29756D3A0027CE40 /* HomeCellHeaderView.swift */; };
@@ -175,6 +176,7 @@
 		2C4041D129ACDC58009247E7 /* SearchListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListViewController.swift; sourceTree = "<group>"; };
 		2C4041D329ACDC67009247E7 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
 		2C4041D529AD1211009247E7 /* SearchListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListTableViewCell.swift; sourceTree = "<group>"; };
+		2C4A266529C320B5009F288F /* BrandSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandSearchViewController.swift; sourceTree = "<group>"; };
 		2C4DD36B29754B3A0027CE40 /* HomeTopCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTopCell.swift; sourceTree = "<group>"; };
 		2C4DD36D29754B410027CE40 /* HomeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCell.swift; sourceTree = "<group>"; };
 		2C4DD36F29756D3A0027CE40 /* HomeCellHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellHeaderView.swift; sourceTree = "<group>"; };
@@ -503,6 +505,7 @@
 		2C39AA4E29704253000C6F71 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				2C4A266029C3207C009F288F /* Brand */,
 				2C700DE629C1988000DDEF77 /* Home */,
 				2C04249729A6565E009CF0FE /* CommentWrite */,
 				2C04248C29A50439009CF0FE /* CommentDetail */,
@@ -611,6 +614,46 @@
 				2CAB7A9C29B08E4100E74809 /* Product.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		2C4A266029C3207C009F288F /* Brand */ = {
+			isa = PBXGroup;
+			children = (
+				2C4A266429C32098009F288F /* Reactor */,
+				2C4A266329C32091009F288F /* Model */,
+				2C4A266229C3208D009F288F /* View */,
+				2C4A266129C32087009F288F /* VIewController */,
+			);
+			path = Brand;
+			sourceTree = "<group>";
+		};
+		2C4A266129C32087009F288F /* VIewController */ = {
+			isa = PBXGroup;
+			children = (
+				2C4A266529C320B5009F288F /* BrandSearchViewController.swift */,
+			);
+			path = VIewController;
+			sourceTree = "<group>";
+		};
+		2C4A266229C3208D009F288F /* View */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		2C4A266329C32091009F288F /* Model */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		2C4A266429C32098009F288F /* Reactor */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Reactor;
 			sourceTree = "<group>";
 		};
 		2C4DD366297547620027CE40 /* View */ = {
@@ -1092,6 +1135,7 @@
 				2C710EF1297BCC33006BE23B /* UIViewController++Extenstions.swift in Sources */,
 				CA5D24A12983EFAB0014ADF8 /* UIStackView++Extenstions.swift in Sources */,
 				2C60F22029BA0F4000595EF4 /* Int++Extenstions.swift in Sources */,
+				2C4A266629C320B5009F288F /* BrandSearchViewController.swift in Sources */,
 				2C04248B29A4FABA009CF0FE /* CommentSection.swift in Sources */,
 				2C4041CE29ACD94D009247E7 /* SearchBarContainerView.swift in Sources */,
 				2C04249229A504D3009CF0FE /* CommentDetailViewController.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		2C4041D429ACDC67009247E7 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041D329ACDC67009247E7 /* SearchResultViewController.swift */; };
 		2C4041D629AD1211009247E7 /* SearchListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4041D529AD1211009247E7 /* SearchListTableViewCell.swift */; };
 		2C4A266629C320B5009F288F /* BrandSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4A266529C320B5009F288F /* BrandSearchViewController.swift */; };
+		2C4A266829C32636009F288F /* BrandSearchReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4A266729C32636009F288F /* BrandSearchReactor.swift */; };
 		2C4DD36C29754B3A0027CE40 /* HomeTopCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36B29754B3A0027CE40 /* HomeTopCell.swift */; };
 		2C4DD36E29754B410027CE40 /* HomeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36D29754B410027CE40 /* HomeCell.swift */; };
 		2C4DD37029756D3A0027CE40 /* HomeCellHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4DD36F29756D3A0027CE40 /* HomeCellHeaderView.swift */; };
@@ -177,6 +178,7 @@
 		2C4041D329ACDC67009247E7 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
 		2C4041D529AD1211009247E7 /* SearchListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListTableViewCell.swift; sourceTree = "<group>"; };
 		2C4A266529C320B5009F288F /* BrandSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandSearchViewController.swift; sourceTree = "<group>"; };
+		2C4A266729C32636009F288F /* BrandSearchReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandSearchReactor.swift; sourceTree = "<group>"; };
 		2C4DD36B29754B3A0027CE40 /* HomeTopCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTopCell.swift; sourceTree = "<group>"; };
 		2C4DD36D29754B410027CE40 /* HomeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCell.swift; sourceTree = "<group>"; };
 		2C4DD36F29756D3A0027CE40 /* HomeCellHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellHeaderView.swift; sourceTree = "<group>"; };
@@ -652,6 +654,7 @@
 		2C4A266429C32098009F288F /* Reactor */ = {
 			isa = PBXGroup;
 			children = (
+				2C4A266729C32636009F288F /* BrandSearchReactor.swift */,
 			);
 			path = Reactor;
 			sourceTree = "<group>";
@@ -1146,6 +1149,7 @@
 				2C39AA20296DB4DE000C6F71 /* HMOA_iOS.xcdatamodeld in Sources */,
 				CAFA450E29AB7E1300ACF2C1 /* StartViewModel.swift in Sources */,
 				2C1BD6C42997A6F80059A43D /* CommentFooterView.swift in Sources */,
+				2C4A266829C32636009F288F /* BrandSearchReactor.swift in Sources */,
 				CA051CB0297FDA0F001865F5 /* StartViewController.swift in Sources */,
 				CA91448F297E760800762BC0 /* UITextField++Extenstions.swift in Sources */,
 				CAFA450A29AB7DEA00ACF2C1 /* ChoiceYearViewController.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		2C710EFC297C15DF006BE23B /* MyPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C710EFB297C15DF006BE23B /* MyPageCell.swift */; };
 		2C710EFF297C1840006BE23B /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C710EFE297C183F006BE23B /* MyPageViewModel.swift */; };
 		2C724E2F29AB1A120057D9B4 /* CommentListTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C724E2E29AB1A120057D9B4 /* CommentListTopView.swift */; };
+		2C730DD929C4A46C001E2B87 /* BrandListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C730DD829C4A46C001E2B87 /* BrandListCollectionViewCell.swift */; };
+		2C730DDB29C4AC06001E2B87 /* Brand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C730DDA29C4AC06001E2B87 /* Brand.swift */; };
 		2CAB7A9829B07A2300E74809 /* SearchResultTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */; };
 		2CAB7A9A29B08BBA00E74809 /* SearchResultCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */; };
 		2CAB7A9D29B08E4100E74809 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9C29B08E4100E74809 /* Product.swift */; };
@@ -196,6 +198,8 @@
 		2C710EFB297C15DF006BE23B /* MyPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCell.swift; sourceTree = "<group>"; };
 		2C710EFE297C183F006BE23B /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		2C724E2E29AB1A120057D9B4 /* CommentListTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListTopView.swift; sourceTree = "<group>"; };
+		2C730DD829C4A46C001E2B87 /* BrandListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandListCollectionViewCell.swift; sourceTree = "<group>"; };
+		2C730DDA29C4AC06001E2B87 /* Brand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Brand.swift; sourceTree = "<group>"; };
 		2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultTopView.swift; sourceTree = "<group>"; };
 		2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCollectionViewCell.swift; sourceTree = "<group>"; };
 		2CAB7A9C29B08E4100E74809 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
@@ -640,6 +644,7 @@
 		2C4A266229C3208D009F288F /* View */ = {
 			isa = PBXGroup;
 			children = (
+				2C730DD829C4A46C001E2B87 /* BrandListCollectionViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -647,6 +652,7 @@
 		2C4A266329C32091009F288F /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				2C730DDA29C4AC06001E2B87 /* Brand.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1146,6 +1152,7 @@
 				2CAB7A9A29B08BBA00E74809 /* SearchResultCollectionViewCell.swift in Sources */,
 				2C39AA7F29705B4C000C6F71 /* UITabBarItem++Extensions.swift in Sources */,
 				CA914498297E873300762BC0 /* UIFont++Extenstions.swift in Sources */,
+				2C730DDB29C4AC06001E2B87 /* Brand.swift in Sources */,
 				2C39AA20296DB4DE000C6F71 /* HMOA_iOS.xcdatamodeld in Sources */,
 				CAFA450E29AB7E1300ACF2C1 /* StartViewModel.swift in Sources */,
 				2C1BD6C42997A6F80059A43D /* CommentFooterView.swift in Sources */,
@@ -1193,6 +1200,7 @@
 				2C39AA18296DB4DE000C6F71 /* SceneDelegate.swift in Sources */,
 				2C04246129A37F7B009CF0FE /* HomeViewReactor.swift in Sources */,
 				2C1BD6A9298FAA370059A43D /* CommentCell.swift in Sources */,
+				2C730DD929C4A46C001E2B87 /* BrandListCollectionViewCell.swift in Sources */,
 				2C710EF5297C0C8C006BE23B /* MyPageTopView.swift in Sources */,
 				2C710EF8297C0F5E006BE23B /* MyPageView.swift in Sources */,
 				2C04247729A3FCED009CF0FE /* PerfumeInfoViewReactor.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		2C724E2F29AB1A120057D9B4 /* CommentListTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C724E2E29AB1A120057D9B4 /* CommentListTopView.swift */; };
 		2C730DD929C4A46C001E2B87 /* BrandListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C730DD829C4A46C001E2B87 /* BrandListCollectionViewCell.swift */; };
 		2C730DDB29C4AC06001E2B87 /* Brand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C730DDA29C4AC06001E2B87 /* Brand.swift */; };
+		2C730DDD29C4AD1C001E2B87 /* BrandListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C730DDC29C4AD1C001E2B87 /* BrandListHeaderView.swift */; };
+		2C730DDF29C4B2FD001E2B87 /* BrandSearchSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C730DDE29C4B2FD001E2B87 /* BrandSearchSection.swift */; };
 		2CAB7A9829B07A2300E74809 /* SearchResultTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */; };
 		2CAB7A9A29B08BBA00E74809 /* SearchResultCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */; };
 		2CAB7A9D29B08E4100E74809 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9C29B08E4100E74809 /* Product.swift */; };
@@ -200,6 +202,8 @@
 		2C724E2E29AB1A120057D9B4 /* CommentListTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListTopView.swift; sourceTree = "<group>"; };
 		2C730DD829C4A46C001E2B87 /* BrandListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandListCollectionViewCell.swift; sourceTree = "<group>"; };
 		2C730DDA29C4AC06001E2B87 /* Brand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Brand.swift; sourceTree = "<group>"; };
+		2C730DDC29C4AD1C001E2B87 /* BrandListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandListHeaderView.swift; sourceTree = "<group>"; };
+		2C730DDE29C4B2FD001E2B87 /* BrandSearchSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandSearchSection.swift; sourceTree = "<group>"; };
 		2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultTopView.swift; sourceTree = "<group>"; };
 		2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCollectionViewCell.swift; sourceTree = "<group>"; };
 		2CAB7A9C29B08E4100E74809 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
@@ -645,6 +649,7 @@
 			isa = PBXGroup;
 			children = (
 				2C730DD829C4A46C001E2B87 /* BrandListCollectionViewCell.swift */,
+				2C730DDC29C4AD1C001E2B87 /* BrandListHeaderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -653,6 +658,7 @@
 			isa = PBXGroup;
 			children = (
 				2C730DDA29C4AC06001E2B87 /* Brand.swift */,
+				2C730DDE29C4B2FD001E2B87 /* BrandSearchSection.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1152,6 +1158,7 @@
 				2CAB7A9A29B08BBA00E74809 /* SearchResultCollectionViewCell.swift in Sources */,
 				2C39AA7F29705B4C000C6F71 /* UITabBarItem++Extensions.swift in Sources */,
 				CA914498297E873300762BC0 /* UIFont++Extenstions.swift in Sources */,
+				2C730DDF29C4B2FD001E2B87 /* BrandSearchSection.swift in Sources */,
 				2C730DDB29C4AC06001E2B87 /* Brand.swift in Sources */,
 				2C39AA20296DB4DE000C6F71 /* HMOA_iOS.xcdatamodeld in Sources */,
 				CAFA450E29AB7E1300ACF2C1 /* StartViewModel.swift in Sources */,
@@ -1209,6 +1216,7 @@
 				CA5D249F2983EEE50014ADF8 /* UILabel++Extenstions.swift in Sources */,
 				CAFA450829AB7DC300ACF2C1 /* YearModel.swift in Sources */,
 				2C60F22C29BA130300595EF4 /* HPediaViewController.swift in Sources */,
+				2C730DDD29C4AD1C001E2B87 /* BrandListHeaderView.swift in Sources */,
 				2C4DD3742976E1A70027CE40 /* HomeView.swift in Sources */,
 				2C710EFC297C15DF006BE23B /* MyPageCell.swift in Sources */,
 				2C39AA7B29705524000C6F71 /* UIColor++Extenstions.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -62,6 +62,12 @@ extension UIViewController {
         self.navigationController?.pushViewController(commentWriteVC, animated: true)
     }
     
+    func presentBrandSearchViewController() {
+        let brandSearchVC = BrandSearchViewController()
+        brandSearchVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(brandSearchVC, animated: true)
+    }
+    
     func setNavigationColor() {
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = .white

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -65,6 +65,7 @@ extension UIViewController {
     func presentBrandSearchViewController() {
         let brandSearchVC = BrandSearchViewController()
         brandSearchVC.hidesBottomBarWhenPushed = true
+        brandSearchVC.reactor = BrandSearchReactor()
         self.navigationController?.pushViewController(brandSearchVC, animated: true)
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Model/Brand.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Model/Brand.swift
@@ -1,0 +1,11 @@
+//
+//  Brand.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/17.
+//
+
+struct Brand: Equatable {
+    var brandId: Int
+    var brandName: String
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Model/Brand.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Model/Brand.swift
@@ -5,6 +5,11 @@
 //  Created by 임현규 on 2023/03/17.
 //
 
+struct BrandList: Equatable {
+    var consonant: String
+    var brands: [Brand]
+}
+
 struct Brand: Equatable {
     var brandId: Int
     var brandName: String

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Model/BrandSearchSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Model/BrandSearchSection.swift
@@ -1,0 +1,24 @@
+//
+//  BrandSearchSection.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/17.
+//
+
+import UIKit
+import RxDataSources
+
+typealias BrandSectionModel = SectionModel<BrandListSection, BrandCell>
+        
+enum BrandListSection: Equatable {
+    case first // ㄱ
+    case second // ㄴ
+    case third // ㄷ
+    case fourth // ㄹ
+    case five // ㅁ
+}
+    
+enum BrandCell: Equatable {
+    case BrandItem(Brand)
+}
+

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Reactor/BrandSearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Reactor/BrandSearchReactor.swift
@@ -12,22 +12,36 @@ class BrandSearchReactor: Reactor {
     var initialState: State = State()
     
     enum Action {
-        
+        case didTapBackButton
     }
     
     enum Mutation {
-        
+        case setIsPopVC(Bool)
     }
     
     struct State {
-        
+        var isPopVC: Bool = false
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
-        <#code#>
+        
+        switch action {
+        case .didTapBackButton:
+            return .concat([
+                .just(.setIsPopVC(true)),
+                .just(.setIsPopVC(false))
+            ])
+        }
     }
     
     func reduce(state: State, mutation: Mutation) -> State {
-        <#code#>
+        var state = state
+        
+        switch mutation {
+        case .setIsPopVC(let isPop):
+            state.isPopVC = isPop
+        }
+        
+        return state
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Reactor/BrandSearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Reactor/BrandSearchReactor.swift
@@ -18,12 +18,27 @@ class BrandSearchReactor: Reactor {
     
     enum Mutation {
         case setIsPopVC(Bool)
-        case setBrandList([Brand])
+        case setBrandList([BrandList])
     }
     
     struct State {
         var isPopVC: Bool = false
-        var brandList: [Brand] = []
+        var brandList: [BrandList] = []
+        var firstSection = BrandSectionModel(
+            model: .first,
+            items: [])
+        var secondSection = BrandSectionModel(
+            model: .second,
+            items: [])
+        var thridSection = BrandSectionModel(
+            model: .third,
+            items: [])
+        var fourthSection = BrandSectionModel(
+            model: .fourth,
+            items: [])
+        var fiveSection = BrandSectionModel(
+            model: .five,
+            items: [])
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -48,7 +63,26 @@ class BrandSearchReactor: Reactor {
             state.isPopVC = isPop
             
         case .setBrandList(let list):
-            state.brandList = list
+            
+            state.firstSection = BrandSectionModel(
+                model: .first,
+                items: list[0].brands.map(BrandCell.BrandItem))
+                
+            state.secondSection = BrandSectionModel(
+                model: .first,
+                items: list[1].brands.map(BrandCell.BrandItem))
+                
+            state.thridSection = BrandSectionModel(
+                model: .first,
+                items: list[2].brands.map(BrandCell.BrandItem))
+                    
+            state.fourthSection = BrandSectionModel(
+                model: .first,
+                items: list[3].brands.map(BrandCell.BrandItem))
+            
+            state.fiveSection = BrandSectionModel(
+                model: .five,
+                items: list[4].brands.map(BrandCell.BrandItem))
         }
         
         return state
@@ -59,24 +93,46 @@ extension BrandSearchReactor {
     
     func reqeustBrandList() -> Observable<Mutation>{
         
-        let data: [Brand] = [
-            Brand(brandId: 1, brandName: "구찌"),
-            Brand(brandId: 2, brandName: "구찌"),
-            Brand(brandId: 3, brandName: "구찌"),
-            Brand(brandId: 4, brandName: "구찌"),
-            Brand(brandId: 5, brandName: "구찌"),
-            Brand(brandId: 6, brandName: "구찌"),
-            Brand(brandId: 7, brandName: "구찌"),
-            Brand(brandId: 8, brandName: "구찌"),
-            Brand(brandId: 9, brandName: "구찌"),
-            Brand(brandId: 10, brandName: "구찌"),
-            Brand(brandId: 11, brandName: "구찌"),
-            Brand(brandId: 12, brandName: "구찌"),
-            Brand(brandId: 13, brandName: "구찌"),
-            Brand(brandId: 14, brandName: "구찌"),
-            Brand(brandId: 15, brandName: "구찌"),
-            Brand(brandId: 16, brandName: "구찌"),
-            Brand(brandId: 17, brandName: "구찌")
+        let data: [BrandList] = [
+            BrandList(consonant: "ㄱ", brands: [
+                Brand(brandId: 1, brandName: "가"),
+                Brand(brandId: 2, brandName: "가"),
+                Brand(brandId: 3, brandName: "가"),
+                Brand(brandId: 4, brandName: "가"),
+                Brand(brandId: 5, brandName: "가")
+            ]),
+            
+            BrandList(consonant: "ㄴ", brands: [
+                Brand(brandId: 6, brandName: "나"),
+                Brand(brandId: 7, brandName: "나"),
+                Brand(brandId: 8, brandName: "나"),
+                Brand(brandId: 9, brandName: "나"),
+                Brand(brandId: 10, brandName: "나")
+            ]),
+            
+            BrandList(consonant: "ㄷ", brands: [
+                Brand(brandId: 11, brandName: "다"),
+                Brand(brandId: 12, brandName: "다"),
+                Brand(brandId: 13, brandName: "다"),
+                Brand(brandId: 14, brandName: "다"),
+                Brand(brandId: 15, brandName: "다")
+            ]),
+            
+            BrandList(consonant: "ㄹ", brands: [
+                Brand(brandId: 16, brandName: "라"),
+                Brand(brandId: 17, brandName: "라"),
+                Brand(brandId: 18, brandName: "라"),
+                Brand(brandId: 19, brandName: "라"),
+                Brand(brandId: 20, brandName: "라")
+            ]),
+            
+            BrandList(consonant: "ㅁ", brands: [
+                Brand(brandId: 21, brandName: "마"),
+                Brand(brandId: 22, brandName: "마"),
+                Brand(brandId: 23, brandName: "마"),
+                Brand(brandId: 24, brandName: "마"),
+                Brand(brandId: 25, brandName: "마")
+            ])
         ]
         
         return .just(.setBrandList(data))

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Reactor/BrandSearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Reactor/BrandSearchReactor.swift
@@ -1,0 +1,33 @@
+//
+//  BrandSearchReactor.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/16.
+//
+
+import ReactorKit
+import RxSwift
+
+class BrandSearchReactor: Reactor {
+    var initialState: State = State()
+    
+    enum Action {
+        
+    }
+    
+    enum Mutation {
+        
+    }
+    
+    struct State {
+        
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        <#code#>
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        <#code#>
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Reactor/BrandSearchReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/Reactor/BrandSearchReactor.swift
@@ -12,15 +12,18 @@ class BrandSearchReactor: Reactor {
     var initialState: State = State()
     
     enum Action {
+        case viewDidLoad
         case didTapBackButton
     }
     
     enum Mutation {
         case setIsPopVC(Bool)
+        case setBrandList([Brand])
     }
     
     struct State {
         var isPopVC: Bool = false
+        var brandList: [Brand] = []
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -31,6 +34,9 @@ class BrandSearchReactor: Reactor {
                 .just(.setIsPopVC(true)),
                 .just(.setIsPopVC(false))
             ])
+            
+        case .viewDidLoad:
+            return reqeustBrandList()
         }
     }
     
@@ -40,8 +46,39 @@ class BrandSearchReactor: Reactor {
         switch mutation {
         case .setIsPopVC(let isPop):
             state.isPopVC = isPop
+            
+        case .setBrandList(let list):
+            state.brandList = list
         }
         
         return state
+    }
+}
+
+extension BrandSearchReactor {
+    
+    func reqeustBrandList() -> Observable<Mutation>{
+        
+        let data: [Brand] = [
+            Brand(brandId: 1, brandName: "구찌"),
+            Brand(brandId: 2, brandName: "구찌"),
+            Brand(brandId: 3, brandName: "구찌"),
+            Brand(brandId: 4, brandName: "구찌"),
+            Brand(brandId: 5, brandName: "구찌"),
+            Brand(brandId: 6, brandName: "구찌"),
+            Brand(brandId: 7, brandName: "구찌"),
+            Brand(brandId: 8, brandName: "구찌"),
+            Brand(brandId: 9, brandName: "구찌"),
+            Brand(brandId: 10, brandName: "구찌"),
+            Brand(brandId: 11, brandName: "구찌"),
+            Brand(brandId: 12, brandName: "구찌"),
+            Brand(brandId: 13, brandName: "구찌"),
+            Brand(brandId: 14, brandName: "구찌"),
+            Brand(brandId: 15, brandName: "구찌"),
+            Brand(brandId: 16, brandName: "구찌"),
+            Brand(brandId: 17, brandName: "구찌")
+        ]
+        
+        return .just(.setBrandList(data))
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/VIewController/BrandSearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/VIewController/BrandSearchViewController.swift
@@ -9,7 +9,47 @@ import UIKit
 
 class BrandSearchViewController: UIViewController {
 
+    // MARK: - UI Component
+    lazy var backButton = UIButton().makeImageButton(UIImage(named: "backButton")!)
+    
+    lazy var searchBar = UISearchBar().then {
+        $0.showsBookmarkButton = true
+        $0.setImage(UIImage(named: "clearButton"), for: .clear, state: .normal)
+        $0.setImage(UIImage(named: "search")?.withTintColor(.customColor(.gray3)), for: .bookmark, state: .normal)
+        $0.searchTextField.leftView = UIView()
+        $0.searchTextField.backgroundColor = .white
+        $0.searchTextField.textAlignment = .left
+        $0.searchTextField.font = .customFont(.pretendard_light, 16)
+        $0.placeholder = "제품/브랜드/키워드 검색"
+    }
+    
+    
+    // MARK: - Life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureUI()
+        configureNavigationBar()
+    }
+}
+
+extension BrandSearchViewController {
+    
+    // MARK: - Configure
+    
+    func configureUI() {
+        view.backgroundColor = .white
+    }
+    
+    func configureNavigationBar() {
+     
+        let backButtonItem = UIBarButtonItem(customView: backButton)
+        
+        let searchBarWrapper = SearchBarContainerView(customSearchBar: searchBar)
+        
+        searchBarWrapper.frame = CGRect(x: 0, y: 0, width: self.navigationController!.view.frame.size.width - 42, height: 30)
+        
+        self.navigationItem.leftBarButtonItems = [backButtonItem]
+        
+        self.navigationItem.titleView = searchBarWrapper
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/VIewController/BrandSearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/VIewController/BrandSearchViewController.swift
@@ -6,8 +6,17 @@
 //
 
 import UIKit
+import SnapKit
+import Then
+import ReactorKit
+import RxSwift
+import RxCocoa
 
-class BrandSearchViewController: UIViewController {
+class BrandSearchViewController: UIViewController, View {
+    typealias Reactor = BrandSearchReactor
+    
+    var disposeBag = DisposeBag()
+    
 
     // MARK: - UI Component
     lazy var backButton = UIButton().makeImageButton(UIImage(named: "backButton")!)
@@ -33,6 +42,11 @@ class BrandSearchViewController: UIViewController {
 }
 
 extension BrandSearchViewController {
+    // MARK: - bind
+    
+    func bind(reactor: BrandSearchReactor) {
+        <#code#>
+    }
     
     // MARK: - Configure
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/VIewController/BrandSearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/VIewController/BrandSearchViewController.swift
@@ -29,7 +29,7 @@ class BrandSearchViewController: UIViewController, View {
         $0.searchTextField.backgroundColor = .white
         $0.searchTextField.textAlignment = .left
         $0.searchTextField.font = .customFont(.pretendard_light, 16)
-        $0.placeholder = "제품/브랜드/키워드 검색"
+        $0.placeholder = "브랜드 검색"
     }
     
     
@@ -45,7 +45,25 @@ extension BrandSearchViewController {
     // MARK: - bind
     
     func bind(reactor: BrandSearchReactor) {
-        <#code#>
+        
+        // MARK: - Action
+        
+        // 뒤로가기 버튼 클릭
+        backButton.rx.tap
+            .map { Reactor.Action.didTapBackButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        // MARK: - State
+        
+        // 이전 화면으로 이동
+        reactor.state
+            .map { $0.isPopVC }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in }
+            .bind(onNext: popViewController)
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Configure

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/VIewController/BrandSearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/VIewController/BrandSearchViewController.swift
@@ -1,0 +1,15 @@
+//
+//  BrandSearchViewController.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/16.
+//
+
+import UIKit
+
+class BrandSearchViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/VIewController/BrandSearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/VIewController/BrandSearchViewController.swift
@@ -32,6 +32,12 @@ class BrandSearchViewController: UIViewController, View {
         $0.placeholder = "브랜드 검색"
     }
     
+    lazy var layout = UICollectionViewFlowLayout()
+
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout).then {
+        $0.register(BrandListCollectionViewCell.self, forCellWithReuseIdentifier: BrandListCollectionViewCell.identifier)
+    }
+    
     
     // MARK: - Life cycle
     override func viewDidLoad() {
@@ -47,12 +53,18 @@ extension BrandSearchViewController {
     func bind(reactor: BrandSearchReactor) {
         
         // MARK: - Action
+        rx.viewDidLoad
+            .map { _ in Reactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         
         // 뒤로가기 버튼 클릭
         backButton.rx.tap
             .map { Reactor.Action.didTapBackButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
         
         // MARK: - State
         
@@ -64,12 +76,32 @@ extension BrandSearchViewController {
             .map { _ in }
             .bind(onNext: popViewController)
             .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.brandList }
+            .distinctUntilChanged()
+            .bind(to: collectionView.rx.items(cellIdentifier: BrandListCollectionViewCell.identifier, cellType: BrandListCollectionViewCell.self)) { index, item, cell in
+                cell.updateCell(item)
+            }
+            .disposed(by: disposeBag)
+        
     }
     
     // MARK: - Configure
     
     func configureUI() {
+        
+        collectionView.rx.setDelegate(self)
+            .disposed(by: disposeBag)
+        
         view.backgroundColor = .white
+        
+        view.addSubview(collectionView)
+        
+        collectionView.snp.makeConstraints {
+            $0.top.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+        }
     }
     
     func configureNavigationBar() {
@@ -83,5 +115,23 @@ extension BrandSearchViewController {
         self.navigationItem.leftBarButtonItems = [backButtonItem]
         
         self.navigationItem.titleView = searchBarWrapper
+    }
+}
+
+extension BrandSearchViewController: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = (UIScreen.main.bounds.width - 56) / 4
+        let heigth = width + 36
+        
+        return CGSize(width: width, height: heigth)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return 8
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/View/BrandListCollectionViewCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/View/BrandListCollectionViewCell.swift
@@ -1,0 +1,59 @@
+//
+//  BrandListCollectionViewCell.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/17.
+//
+
+import UIKit
+
+class BrandListCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: - identifier
+    static let identifier = "BrandListCollectionViewCell"
+    
+    // MARK: - UI Component
+    lazy var brandImageView = UIImageView().then {
+        $0.backgroundColor = .customColor(.gray3)
+    }
+    
+    lazy var brandLabel = UILabel().then {
+        $0.font = .customFont(.pretendard, 14)
+    }
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension BrandListCollectionViewCell {
+    
+    // MARK: - Configure
+    func configureUI() {
+        
+        [   brandImageView,
+            brandLabel
+        ]   .forEach { addSubview($0) }
+        
+        brandImageView.snp.makeConstraints {
+            $0.top.leading.equalToSuperview()
+            $0.width.equalTo((UIScreen.main.bounds.width - 56) / 4)
+            $0.height.equalTo(brandImageView.snp.width)
+        }
+        
+        brandLabel.snp.makeConstraints {
+            $0.top.equalTo(brandImageView.snp.bottom).offset(8)
+            $0.leading.trailing.equalToSuperview()
+        }
+    }
+    
+    func updateCell(_ item: Brand)  {
+        self.brandLabel.text = item.brandName
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/View/BrandListHeaderView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Brand/View/BrandListHeaderView.swift
@@ -1,0 +1,54 @@
+//
+//  BrandListHeaderView.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/17.
+//
+
+import UIKit
+
+class BrandListHeaderView: UICollectionReusableView {
+        
+    // MARK: - identifier
+    static let identifier = "BrandListHeaderView"
+    
+    // MARK: - UI Component
+    var consonantLabel = UILabel().then {
+        $0.clipsToBounds = true
+        $0.textAlignment = .center
+        $0.layer.cornerRadius = 10
+        $0.backgroundColor = .black
+        $0.textColor = .white
+        $0.font = .customFont(.pretendard, 14)
+    }
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension BrandListHeaderView {
+    
+    // MARK: - configure
+    func configureUI() {
+        
+        addSubview(consonantLabel)
+        
+        consonantLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+            $0.width.equalTo(37)
+            $0.height.equalTo(22)
+        }
+    }
+    
+    func updateUI(_ item: String) {
+        consonantLabel.text = item
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
@@ -14,15 +14,24 @@ final class HomeViewReactor: Reactor {
     
     enum Action {
         case itemSelected(IndexPath)
+        case didTapBrandSearchButton
+        case didTapSearchButton
+        case didTapBellButton
     }
     
     enum Mutation {
         case setSelectedPerfumeId(IndexPath?)
+        case setIsPresentBrandSearchVC(Bool)
+        case setIsPresentSearchVC(Bool)
+        case setIsPresentBellVC(Bool)
     }
     
     struct State {
         var sections: [HomeSection]
         var selectedPerfumeId: Int?
+        var isPresentBrandSearchVC: Bool = false
+        var isPresentSearchVC: Bool = false
+        var isPresentBellVC: Bool = false
     }
     
     init() {
@@ -38,6 +47,23 @@ final class HomeViewReactor: Reactor {
             return .concat([
                 Observable<Mutation>.just(.setSelectedPerfumeId(indexPath)),
                 Observable<Mutation>.just(.setSelectedPerfumeId(nil))
+            ])
+        case .didTapBrandSearchButton:
+            return .concat([
+                .just(.setIsPresentBrandSearchVC(true)),
+                .just(.setIsPresentBrandSearchVC(false))
+            ])
+            
+        case .didTapSearchButton:
+            return .concat([
+                .just(.setIsPresentSearchVC(true)),
+                .just(.setIsPresentSearchVC(false))
+            ])
+        
+        case .didTapBellButton:
+            return .concat([
+                .just(.setIsPresentBellVC(true)),
+                .just(.setIsPresentBellVC(false))
             ])
         }
     }
@@ -57,9 +83,17 @@ final class HomeViewReactor: Reactor {
                 state.selectedPerfumeId = state.sections[indexPath.section].items[indexPath.item].perfumeId
             }
             
-            return state
+        case .setIsPresentBrandSearchVC(let isPresent):
+            state.isPresentBrandSearchVC = isPresent
             
+        case .setIsPresentSearchVC(let isPresent):
+            state.isPresentSearchVC = isPresent
+            
+        case .setIsPresentBellVC(let isPresent):
+            state.isPresentBellVC = isPresent
         }
+        return state
+
     }
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
@@ -21,7 +21,15 @@ class HomeViewController: UIViewController, View {
     private var dataSource: RxCollectionViewSectionedReloadDataSource<HomeSection>!
     var disposeBag = DisposeBag()
 
+    // MARK: - UI Component
     lazy var homeView = HomeView()
+    
+    lazy var brandSearchButton = UIButton().makeImageButton(UIImage(named: "homeMenu")!)
+    
+    lazy var searchButton = UIButton().makeImageButton(UIImage(named: "search")!)
+    
+    lazy var bellButton = UIButton().makeImageButton(UIImage(named: "bell")!)
+    
         
     // MARK: - Lifecycle
     override func viewDidLoad() {
@@ -33,12 +41,6 @@ class HomeViewController: UIViewController, View {
     }
     
     // MARK: objc functions
-    
-    @objc func leftButtonClicked() {
-    }
-    
-    @objc func rightButtonClicked() {
-    }
     
     @objc func menuButtonClicked() {
     }
@@ -66,18 +68,56 @@ extension HomeViewController {
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
+        // 브랜드 검색 버튼 클릭
+        brandSearchButton.rx.tap
+            .map { Reactor.Action.didTapBrandSearchButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        // 종합 검색 버튼 클릭
+        searchButton.rx.tap
+            .map { Reactor.Action.didTapSearchButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        // 알림 버튼 클릭
+        bellButton.rx.tap
+            .map { Reactor.Action.didTapBellButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: - State
         
         // collectionView 바인딩
-        reactor.state.map { $0.sections }
+        reactor.state
+            .map { $0.sections }
             .bind(to: self.homeView.collectionView.rx.items(dataSource: self.dataSource))
             .disposed(by: disposeBag)
 
         // 향수 디테일 페이지로 이동
-        reactor.state.map { $0.selectedPerfumeId }
+        reactor.state
+            .map { $0.selectedPerfumeId }
             .distinctUntilChanged()
             .compactMap { $0 }
             .bind(onNext: presentDatailViewController)
+            .disposed(by: disposeBag)
+        
+        // 브랜드 검색 페이지로 이동
+        reactor.state
+            .map { $0.isPresentBrandSearchVC }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in }
+            .bind(onNext: presentBrandSearchViewController)
+            .disposed(by: disposeBag)
+        
+        // 종합 검색 화면으로 이동
+        reactor.state
+            .map { $0.isPresentSearchVC }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in }
+            .bind(onNext: presentSearchViewController)
             .disposed(by: disposeBag)
     }
     
@@ -212,18 +252,16 @@ extension HomeViewController {
             $0.font = .customFont(.pretendard_medium, 20)
             $0.textColor = .black
         }
-        
-        let menuButton = navigationItem.makeImageButtonItem(self, action: #selector(menuButtonClicked), imageName: "homeMenu")
                 
-        let bellButton = navigationItem.makeImageButtonItem(self, action: #selector(bellButtonClicked), imageName: "bell")
-        
-        let searchButton = navigationItem.makeImageButtonItem(self, action: #selector(searchButtonClicked), imageName: "search")
+        let bracnSearchButtonItem = UIBarButtonItem(customView: brandSearchButton)
+        let searchButtonItem = UIBarButtonItem(customView: searchButton)
+        let bellButtonItem = UIBarButtonItem(customView: bellButton)
         
         navigationItem.titleView = titleLabel
         
-        navigationItem.leftBarButtonItems = [spacerItem(13), menuButton]
+        navigationItem.leftBarButtonItems = [spacerItem(13), bracnSearchButtonItem]
         
-        navigationItem.rightBarButtonItems = [bellButton, spacerItem(15), searchButton]
+        navigationItem.rightBarButtonItems = [bellButtonItem, spacerItem(15), searchButtonItem]
     }
     
     func configureUI() {


### PR DESCRIPTION


https://user-images.githubusercontent.com/48830320/226093847-13b96caf-e36b-4f26-bbae-29e7d7a0c7b5.mp4



### 이슈번호
#38 

### 구현/추가사항
- CollectionView와 HeaderView를 이용해서 구현했습니다.
- 자음이 총 14개로 14개의 섹션으로 어떻게 구성할까 고민하다가 검색해봤는데 14개의 섹션을 모두 Reactor에 구현해야되는 것 같아서 일단 그렇게 구현했습니다.
- 일단 임시 데이터는 ㄱ ~ ㅁ 까지 구현해놨고 추후에 나머지 자음까지 구현하도록 하겠습니다.
- 기능적인 부분은 브랜드 검색 결과 페이지 구현한 다음에 작업하도록 하겠습니다.