### PR TITLE
[Feat] 브랜드 상세 페이지 UI 추가 구현

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Model/BrandDetailSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Model/BrandDetailSection.swift
@@ -8,12 +8,31 @@
 import UIKit
 import RxDataSources
 
-typealias BrandDetailModel = SectionModel<BrandDetailSection, BrandDetailSectionItem>
 
 enum BrandDetailSection {
-    case first
+    case first([BrandDetailSectionItem])
 }
 
 enum BrandDetailSectionItem {
     case perfumeList(Perfume)
+}
+
+extension BrandDetailSection: SectionModelType {
+
+    
+    typealias Item = BrandDetailSectionItem
+    
+    var items: [Item] {
+        switch self {
+        case .first(let items):
+            return items
+        }
+    }
+    
+    init(original: BrandDetailSection, items: [BrandDetailSectionItem]) {
+        switch original {
+        case .first:
+            self = .first(items)
+        }
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Reactor/BrandDetailCellReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Reactor/BrandDetailCellReactor.swift
@@ -49,7 +49,7 @@ class BrandDetailCellReactor: Reactor {
         
         switch mutation {
         case .setPerfumeLike(let isLike):
-            state.perfume.isLikePerfume = isLike
+            state.perfume.isLikePerfume = !isLike
         case .setSelectedCell(let perfume):
             state.selectedCell = perfume
         }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Reactor/BrandDetailHeaderReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Reactor/BrandDetailHeaderReactor.swift
@@ -50,6 +50,7 @@ class BrandDetailHeaderReactor: Reactor {
             
         case .didTapSortDropDown(let index, let string):
             return .just(.setSelectedDropDown(index, string))
+            
         }
     }
     
@@ -58,7 +59,7 @@ class BrandDetailHeaderReactor: Reactor {
         
         switch mutation {
         case .setBrandLike(let isLike):
-            state.brandInfo.isLikeBrand = isLike
+            state.brandInfo.isLikeBrand = !isLike
             
         case .setPresentDropDown(let isPresent):
             state.isPresentDropDown = isPresent

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Reactor/BrandDetailHeaderReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Reactor/BrandDetailHeaderReactor.swift
@@ -14,14 +14,20 @@ class BrandDetailHeaderReactor: Reactor {
     
     enum Action {
         case didTapBrandLikeButton(Bool)
+        case didTapSortButton
+        case didTapSortDropDown(Int, String)
     }
     
     enum Mutation {
         case setBrandLike(Bool)
+        case setPresentDropDown(Bool)
+        case setSelectedDropDown(Int, String)
     }
     
     struct State {
         var brandInfo: BrandInfo
+        var isPresentDropDown: Bool = false
+        var nowSortType: String = "추천순"
     }
     
     init(_ brandId: Int) {
@@ -35,6 +41,15 @@ class BrandDetailHeaderReactor: Reactor {
         switch action {
         case .didTapBrandLikeButton(let isLike):
             return .just(.setBrandLike(isLike))
+
+        case .didTapSortButton:
+            return .concat([
+                .just(.setPresentDropDown(true)),
+                .just(.setPresentDropDown(false))
+            ])
+            
+        case .didTapSortDropDown(let index, let string):
+            return .just(.setSelectedDropDown(index, string))
         }
     }
     
@@ -44,6 +59,12 @@ class BrandDetailHeaderReactor: Reactor {
         switch mutation {
         case .setBrandLike(let isLike):
             state.brandInfo.isLikeBrand = isLike
+            
+        case .setPresentDropDown(let isPresent):
+            state.isPresentDropDown = isPresent
+            
+        case .setSelectedDropDown(_, let string):
+            state.nowSortType = string
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Reactor/BrandDetailReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Reactor/BrandDetailReactor.swift
@@ -19,9 +19,7 @@ class BrandDetailReactor: Reactor {
     }
     
     struct State {
-        var section = BrandDetailModel(
-            model: .first,
-            items: [])
+        var section: [BrandDetailSection] = []
         var brandId: Int = 0
         var title: String = ""
         var isPopVC: Bool = false
@@ -30,7 +28,8 @@ class BrandDetailReactor: Reactor {
     var initialState: State
     
     init(_ brandId: Int, _ title: String) {
-        initialState = State(section: BrandDetailReactor.requestBrandInfo(brandId),
+        let perfumeList = BrandDetailReactor.requestBrandInfo(brandId)
+        initialState = State(section: perfumeList,
                              brandId: brandId,
                              title: title)
     }
@@ -61,7 +60,7 @@ class BrandDetailReactor: Reactor {
 
 extension BrandDetailReactor {
     
-    static func requestBrandInfo(_ brandId: Int) -> BrandDetailModel {
+    static func requestBrandInfo(_ brandId: Int) -> [BrandDetailSection] {
         
         // 해당 브랜드 Id로 서버 통신해서 데이터 받아옴
         let perfumeList: [Perfume] = [
@@ -108,8 +107,6 @@ extension BrandDetailReactor {
                 image: UIImage(named: "jomalon")!,
                 isLikePerfume: false)]
         
-        return BrandDetailModel(
-            model: .first,
-            items: perfumeList.map(BrandDetailSectionItem.perfumeList))
+        return [BrandDetailSection.first(perfumeList.map { BrandDetailSectionItem.perfumeList($0) })]
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/View/BrandDetailCollectionViewCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/View/BrandDetailCollectionViewCell.swift
@@ -57,6 +57,12 @@ extension BrandDetailCollectionViewCell {
     
     func bind(reactor: BrandDetailCellReactor) {
         
+        // MARK: - Action
+        likeButton.rx.tap
+            .map { Reactor.Action.didTapPerfumeLikeButton(self.likeButton.isSelected) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: - State
         
         // 향수 브랜드명

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/View/BrandDetailHeaderView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/View/BrandDetailHeaderView.swift
@@ -11,6 +11,7 @@ import Then
 import RxSwift
 import RxCocoa
 import ReactorKit
+import DropDown
 
 class BrandDetailHeaderView: UICollectionReusableView, View {
     typealias Reactor = BrandDetailHeaderReactor
@@ -46,18 +47,22 @@ class BrandDetailHeaderView: UICollectionReusableView, View {
         $0.setImage(UIImage(named: "bottomHeart"), for: .normal)
     }
     
+    
     // TODO: - 드롭다운 라이브러리 사용해서 추후에 구현
-    lazy var filterButton = UIButton().then {
+    lazy var sortButton = UIButton().then {
         $0.titleLabel?.font = .customFont(.pretendard_light, 12)
         $0.setTitleColor(.black, for: .normal)
-        $0.setTitle("최신순", for: .normal)
+//        $0.setTitle("최신순", for: .normal)
     }
+    
+    lazy var sortDropDown = DropDown()
     
     // MARK: - init
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
+        configureDropDown()
     }
     
     required init?(coder: NSCoder) {
@@ -70,6 +75,20 @@ extension BrandDetailHeaderView {
     // MARK: - bind
     func bind(reactor: BrandDetailHeaderReactor) {
         
+        // MARK: - Action
+        
+        // 정렬 버튼 클릭
+        sortButton.rx.tap
+            .map { Reactor.Action.didTapSortButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        // DropDown 아이템 클릭
+        sortDropDown.rx.selectionAction
+            .onNext { (index, string) in
+                reactor.action.onNext(.didTapSortDropDown(index, string))
+            }
+
         // MARK: - State
         
         // 한글 브랜드명
@@ -92,6 +111,24 @@ extension BrandDetailHeaderView {
             .distinctUntilChanged()
             .bind(to: likeButton.rx.isSelected)
             .disposed(by: disposeBag)
+        
+        // DropDown 보여주기
+        reactor.state
+            .map { $0.isPresentDropDown }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in }
+            .bind(onNext: {self.sortDropDown.show()})
+            .disposed(by: disposeBag)
+        
+        // sortButton title바꾸기
+        reactor.state
+            .map { $0.nowSortType }
+            .distinctUntilChanged()
+            .bind(onNext: {
+                self.sortButton.setTitle($0, for: .normal)
+            })
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Configure
@@ -99,7 +136,7 @@ extension BrandDetailHeaderView {
     func configureUI() {
         
         [   brandInfoView,
-            filterButton
+            sortButton
         ]   .forEach { addSubview($0) }
         
         [   englishLabel,
@@ -135,9 +172,21 @@ extension BrandDetailHeaderView {
             $0.width.height.equalTo(100)
         }
         
-        filterButton.snp.makeConstraints {
+        sortButton.snp.makeConstraints {
             $0.top.equalTo(brandInfoView.snp.bottom).offset(16)
-            $0.trailing.equalToSuperview().inset(21)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.width.equalTo(80)
         }
+    }
+    
+    func configureDropDown() {
+        sortDropDown.dataSource = ["추천순", "인기순", "최신순"]
+        sortDropDown.anchorView = self.sortButton
+        sortDropDown.bottomOffset = CGPoint(x: -13, y: 30)
+        
+        sortDropDown.textFont = .customFont(.pretendard_light, 12)
+        sortDropDown.selectedTextColor = .black
+        sortDropDown.textColor = .customColor(.gray3)
+        sortDropDown.selectRow(at: 0)
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/View/BrandDetailHeaderView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/View/BrandDetailHeaderView.swift
@@ -44,7 +44,13 @@ class BrandDetailHeaderView: UICollectionReusableView, View {
     }
     
     lazy var likeButton = UIButton().then {
-        $0.setImage(UIImage(named: "bottomHeart"), for: .normal)
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 14)
+        let normalImage = UIImage(named: "bottomHeart", in: .none, with: imageConfig)
+        let selectedImage = UIImage(named: "bottomHeart", in: .none, with: imageConfig)?.withTintColor(.red)
+        
+        $0.setImage(normalImage, for: .normal)
+        $0.setImage(selectedImage, for: .selected)
+        
     }
     
     
@@ -89,6 +95,12 @@ extension BrandDetailHeaderView {
                 reactor.action.onNext(.didTapSortDropDown(index, string))
             }
 
+        // 브랜드 좋아요 버튼 클릭
+        likeButton.rx.tap
+            .map { Reactor.Action.didTapBrandLikeButton(self.likeButton.isSelected) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: - State
         
         // 한글 브랜드명
@@ -128,6 +140,13 @@ extension BrandDetailHeaderView {
             .bind(onNext: {
                 self.sortButton.setTitle($0, for: .normal)
             })
+            .disposed(by: disposeBag)
+        
+        // 브랜드 좋아요 상태
+        reactor.state
+            .map { $0.brandInfo.isLikeBrand }
+            .distinctUntilChanged()
+            .bind(to: likeButton.rx.isSelected)
             .disposed(by: disposeBag)
     }
     
@@ -184,6 +203,7 @@ extension BrandDetailHeaderView {
         sortDropDown.anchorView = self.sortButton
         sortDropDown.bottomOffset = CGPoint(x: -13, y: 30)
         
+        sortDropDown.backgroundColor = .white
         sortDropDown.textFont = .customFont(.pretendard_light, 12)
         sortDropDown.selectedTextColor = .black
         sortDropDown.textColor = .customColor(.gray3)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/ViewController/BrandDetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/ViewController/BrandDetailViewController.swift
@@ -58,6 +58,7 @@ extension BrandDetailViewController {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        
         // MARK: - State
         
         // CollectionView 바인딩
@@ -81,6 +82,7 @@ extension BrandDetailViewController {
             .map { _ in } 
             .bind(onNext: self.popViewController)
             .disposed(by: disposeBag)
+        
     }
     
     // MARK: - Configure
@@ -160,7 +162,7 @@ extension BrandDetailViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        return CGSize(width: UIScreen.main.bounds.width, height: 242)
+        return CGSize(width: UIScreen.main.bounds.width, height: 256)
     }
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/ViewController/BrandDetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/ViewController/BrandDetailViewController.swift
@@ -20,7 +20,7 @@ class BrandDetailViewController: UIViewController, View {
     var disposeBag = DisposeBag()
     
     // MARK: - UI Component
-    private var dataSource: RxCollectionViewSectionedReloadDataSource<BrandDetailModel>!
+    private var dataSource: RxCollectionViewSectionedReloadDataSource<BrandDetailSection>!
 
     let homeBarButton = UIButton().makeImageButton(UIImage(named: "homeNavi")!)
     let searchBarButton = UIButton().makeImageButton(UIImage(named: "search")!)
@@ -63,7 +63,7 @@ extension BrandDetailViewController {
         
         // CollectionView 바인딩
         reactor.state
-            .map { [$0.section] }
+            .map { $0.section }
             .bind(to: self.collectionView.rx.items(dataSource: self.dataSource))
             .disposed(by: disposeBag)
         
@@ -111,7 +111,7 @@ extension BrandDetailViewController {
     }
     
     func configureCollectionViewDataSource() {
-        dataSource = RxCollectionViewSectionedReloadDataSource<BrandDetailModel>(configureCell: { _, collectionView, indexPath, item -> UICollectionViewCell in
+        dataSource = RxCollectionViewSectionedReloadDataSource<BrandDetailSection>(configureCell: { _, collectionView, indexPath, item -> UICollectionViewCell in
             
             switch item {
             case .perfumeList(let perfume):
@@ -133,12 +133,12 @@ extension BrandDetailViewController {
                 
                 headerView.reactor = BrandDetailHeaderReactor(self.reactor!.currentState.brandId)
                 header = headerView
-                
+                return header
+
             default: return header
                 
             }
             
-            return header
         })
     }
 }


### PR DESCRIPTION


https://user-images.githubusercontent.com/48830320/227171113-42f86718-f6d3-48a2-863b-f574f19bf648.mp4



### 이슈번호
#52 

### 구현/추가사항
- 브랜드 좋아요 버튼 클릭시 버튼 이미지 수정했습니다.
- 향수 좋아요 버튼 클릭시 버튼 이미지 수정했습니다.
- 향수 클릭시 해당 향수 ID값을 가지고 향수 상세화면으로 넘어가게 구현했습니다.
- dropdown 라이브러리 사용해서 정렬화면 UI 구현했습니다. (아직 이미지가 없어서 정렬버튼 옆 화살표는 이미지 설정안해놨습니다.)