### PR TITLE
[Feat] 홈 화면 전체보기 페이지 구현

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -102,6 +102,8 @@
 		2C710EFF297C1840006BE23B /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C710EFE297C183F006BE23B /* MyPageViewModel.swift */; };
 		2C724E2F29AB1A120057D9B4 /* CommentListTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C724E2E29AB1A120057D9B4 /* CommentListTopView.swift */; };
 		2CA7F69529D2E8DB0022E7FD /* TotalPerfumeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA7F69429D2E8DB0022E7FD /* TotalPerfumeViewController.swift */; };
+		2CA7F69A29D2FBE70022E7FD /* TotalPerfumeReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA7F69929D2FBE70022E7FD /* TotalPerfumeReactor.swift */; };
+		2CA7F69D29D2FD180022E7FD /* TotalPerfumeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA7F69C29D2FD180022E7FD /* TotalPerfumeSection.swift */; };
 		2CAB7A9829B07A2300E74809 /* SearchResultTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */; };
 		2CAB7A9A29B08BBA00E74809 /* SearchResultCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */; };
 		2CAB7A9D29B08E4100E74809 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9C29B08E4100E74809 /* Product.swift */; };
@@ -254,6 +256,8 @@
 		2C710EFE297C183F006BE23B /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		2C724E2E29AB1A120057D9B4 /* CommentListTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListTopView.swift; sourceTree = "<group>"; };
 		2CA7F69429D2E8DB0022E7FD /* TotalPerfumeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalPerfumeViewController.swift; sourceTree = "<group>"; };
+		2CA7F69929D2FBE70022E7FD /* TotalPerfumeReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalPerfumeReactor.swift; sourceTree = "<group>"; };
+		2CA7F69C29D2FD180022E7FD /* TotalPerfumeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalPerfumeSection.swift; sourceTree = "<group>"; };
 		2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultTopView.swift; sourceTree = "<group>"; };
 		2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCollectionViewCell.swift; sourceTree = "<group>"; };
 		2CAB7A9C29B08E4100E74809 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
@@ -977,6 +981,8 @@
 		2CA7F69229D2E8BC0022E7FD /* TotalPerfume */ = {
 			isa = PBXGroup;
 			children = (
+				2CA7F69B29D2FD090022E7FD /* Model */,
+				2CA7F69829D2FBDB0022E7FD /* Reactor */,
 				2CA7F69329D2E8CD0022E7FD /* ViewContorller */,
 			);
 			path = TotalPerfume;
@@ -988,6 +994,22 @@
 				2CA7F69429D2E8DB0022E7FD /* TotalPerfumeViewController.swift */,
 			);
 			path = ViewContorller;
+			sourceTree = "<group>";
+		};
+		2CA7F69829D2FBDB0022E7FD /* Reactor */ = {
+			isa = PBXGroup;
+			children = (
+				2CA7F69929D2FBE70022E7FD /* TotalPerfumeReactor.swift */,
+			);
+			path = Reactor;
+			sourceTree = "<group>";
+		};
+		2CA7F69B29D2FD090022E7FD /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				2CA7F69C29D2FD180022E7FD /* TotalPerfumeSection.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		2CAB7A9B29B08E3200E74809 /* Model */ = {
@@ -1473,6 +1495,7 @@
 				2C04249B29A656BB009CF0FE /* CommentWriteViewController.swift in Sources */,
 				2C1BD6B3298FF14F0059A43D /* SimilarHeaderView.swift in Sources */,
 				2C4CDC4829C770D900676163 /* BrandSearchSection.swift in Sources */,
+				2CA7F69A29D2FBE70022E7FD /* TotalPerfumeReactor.swift in Sources */,
 				2C04246429A39C26009CF0FE /* Perfume.swift in Sources */,
 				2C04247129A3E3D4009CF0FE /* PerfumeDetail.swift in Sources */,
 				2C4CDC4B29C770D900676163 /* BrandSearchViewController.swift in Sources */,
@@ -1483,6 +1506,7 @@
 				CA54DD9329C447AB00167F05 /* LikeCardModel.swift in Sources */,
 				2C700DE829C1A84F00DDEF77 /* HomeHeaderReactor.swift in Sources */,
 				CAFB9F4029B5C67B0009654C /* LoginReactor.swift in Sources */,
+				2CA7F69D29D2FD180022E7FD /* TotalPerfumeSection.swift in Sources */,
 				CA91448D297E75C700762BC0 /* LoginViewController.swift in Sources */,
 				2C4DD36C29754B3A0027CE40 /* HomeTopCell.swift in Sources */,
 				CA174F6329BB33AF006E7680 /* StartReactor.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		2C710EFC297C15DF006BE23B /* MyPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C710EFB297C15DF006BE23B /* MyPageCell.swift */; };
 		2C710EFF297C1840006BE23B /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C710EFE297C183F006BE23B /* MyPageViewModel.swift */; };
 		2C724E2F29AB1A120057D9B4 /* CommentListTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C724E2E29AB1A120057D9B4 /* CommentListTopView.swift */; };
+		2CA7F69529D2E8DB0022E7FD /* TotalPerfumeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA7F69429D2E8DB0022E7FD /* TotalPerfumeViewController.swift */; };
 		2CAB7A9829B07A2300E74809 /* SearchResultTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */; };
 		2CAB7A9A29B08BBA00E74809 /* SearchResultCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */; };
 		2CAB7A9D29B08E4100E74809 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB7A9C29B08E4100E74809 /* Product.swift */; };
@@ -252,6 +253,7 @@
 		2C710EFB297C15DF006BE23B /* MyPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCell.swift; sourceTree = "<group>"; };
 		2C710EFE297C183F006BE23B /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		2C724E2E29AB1A120057D9B4 /* CommentListTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListTopView.swift; sourceTree = "<group>"; };
+		2CA7F69429D2E8DB0022E7FD /* TotalPerfumeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalPerfumeViewController.swift; sourceTree = "<group>"; };
 		2CAB7A9729B07A2300E74809 /* SearchResultTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultTopView.swift; sourceTree = "<group>"; };
 		2CAB7A9929B08BBA00E74809 /* SearchResultCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCollectionViewCell.swift; sourceTree = "<group>"; };
 		2CAB7A9C29B08E4100E74809 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
@@ -573,6 +575,7 @@
 		2C39AA4E29704253000C6F71 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				2CA7F69229D2E8BC0022E7FD /* TotalPerfume */,
 				2C4CDC2729C770D900676163 /* BrandDetail */,
 				2C4CDC3429C770D900676163 /* BrandSearch */,
 				2C700DE629C1988000DDEF77 /* Home */,
@@ -969,6 +972,22 @@
 				2C710EFE297C183F006BE23B /* MyPageViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		2CA7F69229D2E8BC0022E7FD /* TotalPerfume */ = {
+			isa = PBXGroup;
+			children = (
+				2CA7F69329D2E8CD0022E7FD /* ViewContorller */,
+			);
+			path = TotalPerfume;
+			sourceTree = "<group>";
+		};
+		2CA7F69329D2E8CD0022E7FD /* ViewContorller */ = {
+			isa = PBXGroup;
+			children = (
+				2CA7F69429D2E8DB0022E7FD /* TotalPerfumeViewController.swift */,
+			);
+			path = ViewContorller;
 			sourceTree = "<group>";
 		};
 		2CAB7A9B29B08E3200E74809 /* Model */ = {
@@ -1420,6 +1439,7 @@
 				CA91448F297E760800762BC0 /* UITextField++Extenstions.swift in Sources */,
 				CAFA450A29AB7DEA00ACF2C1 /* ChoiceYearViewController.swift in Sources */,
 				2C4CDC4129C770D900676163 /* BrandDetailCollectionViewCell.swift in Sources */,
+				2CA7F69529D2E8DB0022E7FD /* TotalPerfumeViewController.swift in Sources */,
 				2CAD9641298E6F6200974500 /* TagListView++Extenstions.swift in Sources */,
 				2C1BD6BE29978EDD0059A43D /* BrandView.swift in Sources */,
 				2CAD9639298E4C1D00974500 /* PerfumeInfoView.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -76,7 +76,7 @@ extension UIViewController {
     
     func presentTotalPerfumeViewController(_ listType: Int) {
         let totalPerfumeVC = TotalPerfumeViewController()
-        
+        totalPerfumeVC.reactor = TotalPerfumeReactor(listType)
         self.navigationController?.pushViewController(totalPerfumeVC, animated: true)
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -74,6 +74,12 @@ extension UIViewController {
         self.navigationController?.pushViewController(brandDetailVC, animated: true)
     }
     
+    func presentTotalPerfumeViewController(_ listType: Int) {
+        let totalPerfumeVC = TotalPerfumeViewController()
+        
+        self.navigationController?.pushViewController(totalPerfumeVC, animated: true)
+    }
+    
     func setNavigationColor() {
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = .white

--- a/HMOA_iOS/HMOA_iOS/Source/Network/ServiceAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/ServiceAPI.swift
@@ -65,4 +65,14 @@ final class API {
             data: nil,
             model: Object.self)
     }
+    
+    static func postPerfumeLike(perfumeId: Int) -> Observable<String> {
+        
+        return networking(
+            urlStr: Address.perfumeOne(perfumeId).url,
+            method: .post,
+            data: nil,
+            model: String.self)
+        
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Reactor/BrandDetailCellReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/BrandDetail/Reactor/BrandDetailCellReactor.swift
@@ -57,3 +57,20 @@ class BrandDetailCellReactor: Reactor {
         return state
     }
 }
+
+extension BrandDetailCellReactor {
+    
+    func postPerfumeLike(_ perfumeId: Int) -> Observable<Mutation> {
+        
+        // TODO: perfumeId로 해당 향수 좋아요 설정
+        
+        return .empty()
+    }
+    
+    func deletePerfumeLike(_ perfumeId: Int) -> Observable<Mutation> {
+        
+        // TODO: perfumeId로 해당 향수 좋아요 삭제
+        
+        return .empty()
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeHeaderReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeHeaderReactor.swift
@@ -25,8 +25,8 @@ class HomeHeaderReactor: Reactor {
         var isPersentMoreVC: Bool = false
     }
     
-    init(_ title: String) {
-        self.initialState = State(headerTitle: title)
+    init(_ title: String, _ listType: Int) {
+        self.initialState = State(headerTitle: title, listType: listType)
     }
     
     func mutate(action: Action) -> Observable<Mutation> {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeHeaderReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeHeaderReactor.swift
@@ -16,13 +16,13 @@ class HomeHeaderReactor: Reactor {
     }
     
     enum Mutation {
-        case setPresentMoreVC(Bool)
+        case setPresentMoreVC(Int?)
     }
     
     struct State {
         var headerTitle: String
         var listType: Int? = nil
-        var isPersentMoreVC: Bool = false
+        var isPersentMoreVC: Int? = nil
     }
     
     init(_ title: String, _ listType: Int) {
@@ -33,8 +33,8 @@ class HomeHeaderReactor: Reactor {
         switch action {
         case .didTapMoreButton:
             return .concat([
-                .just(.setPresentMoreVC(true)),
-                .just(.setPresentMoreVC(false))
+                .just(.setPresentMoreVC(currentState.listType!)),
+                .just(.setPresentMoreVC(nil))
             ])
         }
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/View/HomeFirstCellHeaderView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/View/HomeFirstCellHeaderView.swift
@@ -74,5 +74,10 @@ extension HomeFirstCellHeaderView {
             .distinctUntilChanged()
             .bind(to: titleLabel.rx.text)
             .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isPersentMoreVC }
+            .distinctUntilChanged()
+            .compactMap { $0 }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
@@ -30,7 +30,7 @@ class HomeViewController: UIViewController, View {
     
     lazy var bellButton = UIButton().makeImageButton(UIImage(named: "bell")!)
     
-        
+    var headerViewReactor: HomeHeaderReactor!
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -121,12 +121,18 @@ extension HomeViewController {
             .disposed(by: disposeBag)
     }
     
-    func bindHeader() {
+    func bindHeader(reactor: HomeHeaderReactor) {
         
         // MARK: - Action
         
         // MARK: - State
         
+        reactor.state
+            .map { $0.isPersentMoreVC }
+            .distinctUntilChanged()
+            .compactMap { $0 }
+            .bind(onNext: presentTotalPerfumeViewController)
+            .disposed(by: disposeBag)
     }
     
     func configureCollectionViewDataSource() {
@@ -199,7 +205,7 @@ extension HomeViewController {
                 }
                 
                 homeFirstCellHeader.reactor = HomeHeaderReactor("향모아 사용자들이 좋아한", 1)
-                
+                self.bindHeader(reactor: homeFirstCellHeader.reactor!)
                 header = homeFirstCellHeader
                 
             case 2:
@@ -209,8 +215,9 @@ extension HomeViewController {
                     for: indexPath) as? HomeCellHeaderView else {
                     return UICollectionReusableView()
                 }
-                homeCellheader.reactor = HomeHeaderReactor("이 제품 어떠세요? 향모아가 추천하는", 2)
                 
+                homeCellheader.reactor = HomeHeaderReactor("이 제품 어떠세요? 향모아가 추천하는", 2)
+                self.bindHeader(reactor: homeCellheader.reactor!)
                 header = homeCellheader
                 
             case 3:
@@ -220,7 +227,9 @@ extension HomeViewController {
                     for: indexPath) as? HomeCellHeaderView else {
                     return UICollectionReusableView()
                 }
+                
                 homeCellheader.reactor = HomeHeaderReactor("변함없이 사랑받는, 스테디 셀러", 3)
+                self.bindHeader(reactor: homeCellheader.reactor!)
                 header = homeCellheader
 
 
@@ -233,12 +242,12 @@ extension HomeViewController {
                 }
                 
                 homeCellheader.reactor = HomeHeaderReactor("최근 발매된", 4)
+                self.bindHeader(reactor: homeCellheader.reactor!)
                 header = homeCellheader
 
             default: return header
                 
             }
-            
             return header
         })
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
@@ -198,7 +198,7 @@ extension HomeViewController {
                     return UICollectionReusableView()
                 }
                 
-                homeFirstCellHeader.reactor = HomeHeaderReactor("향모아 사용자들이 좋아한")
+                homeFirstCellHeader.reactor = HomeHeaderReactor("향모아 사용자들이 좋아한", 1)
                 
                 header = homeFirstCellHeader
                 
@@ -209,7 +209,7 @@ extension HomeViewController {
                     for: indexPath) as? HomeCellHeaderView else {
                     return UICollectionReusableView()
                 }
-                homeCellheader.reactor = HomeHeaderReactor("이 제품 어떠세요? 향모아가 추천하는")
+                homeCellheader.reactor = HomeHeaderReactor("이 제품 어떠세요? 향모아가 추천하는", 2)
                 
                 header = homeCellheader
                 
@@ -220,7 +220,7 @@ extension HomeViewController {
                     for: indexPath) as? HomeCellHeaderView else {
                     return UICollectionReusableView()
                 }
-                homeCellheader.reactor = HomeHeaderReactor("변함없이 사랑받는, 스테디 셀러")
+                homeCellheader.reactor = HomeHeaderReactor("변함없이 사랑받는, 스테디 셀러", 3)
                 header = homeCellheader
 
 
@@ -232,7 +232,7 @@ extension HomeViewController {
                     return UICollectionReusableView()
                 }
                 
-                homeCellheader.reactor = HomeHeaderReactor("최근 발매된")
+                homeCellheader.reactor = HomeHeaderReactor("최근 발매된", 4)
                 header = homeCellheader
 
             default: return header

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Model/TotalPerfumeSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Model/TotalPerfumeSection.swift
@@ -16,6 +16,16 @@ enum TotalPerfumeSectionItem {
     case perfumeList(Perfume)
 }
 
+extension TotalPerfumeSectionItem {
+    
+    var perfume: Perfume {
+        switch self {
+        case .perfumeList(let perfume):
+            return perfume
+        }
+    }
+}
+
 extension TotalPerfumeSection: SectionModelType {
     typealias Item = TotalPerfumeSectionItem
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Model/TotalPerfumeSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Model/TotalPerfumeSection.swift
@@ -1,0 +1,36 @@
+//
+//  TotalPerfumeSection.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/28.
+//
+
+import Foundation
+import RxDataSources
+
+enum TotalPerfumeSection {
+    case first([TotalPerfumeSectionItem])
+}
+
+enum TotalPerfumeSectionItem {
+    case perfumeList(Perfume)
+}
+
+extension TotalPerfumeSection: SectionModelType {
+    typealias Item = TotalPerfumeSectionItem
+    
+    
+    var items: [Item] {
+        switch self {
+        case .first(let items):
+            return items
+        }
+    }
+    
+    init(original: TotalPerfumeSection, items: [Item]) {
+        switch original {
+        case .first:
+            self = .first(items)
+        }
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Model/TotalPerfumeSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Model/TotalPerfumeSection.swift
@@ -13,15 +13,15 @@ enum TotalPerfumeSection {
 }
 
 enum TotalPerfumeSectionItem {
-    case perfumeList(Perfume)
+    case perfumeList(BrandDetailCellReactor)
 }
 
 extension TotalPerfumeSectionItem {
-    
+
     var perfume: Perfume {
         switch self {
-        case .perfumeList(let perfume):
-            return perfume
+        case .perfumeList(let reactor):
+            return reactor.currentState.perfume
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Reactor/TotalPerfumeReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Reactor/TotalPerfumeReactor.swift
@@ -11,15 +11,16 @@ import ReactorKit
 class TotalPerfumeReactor: Reactor {
     
     enum Action {
-        
+        case didTapItem(Perfume)
     }
     
     enum Mutation {
-        
+        case setSelectedItem(Perfume?)
     }
     
     struct State {
         var section: [TotalPerfumeSection]
+        var selectedItem: Perfume? = nil
     }
     
     var initialState: State
@@ -29,11 +30,21 @@ class TotalPerfumeReactor: Reactor {
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
-        
+        switch action {
+        case .didTapItem(let perfume):
+            return .just(.setSelectedItem(perfume))
+        }
     }
     
     func reduce(state: State, mutation: Mutation) -> State {
+        var state = state
         
+        switch mutation {
+        case .setSelectedItem(let perfume):
+            state.selectedItem = perfume
+        }
+        
+        return state
     }
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Reactor/TotalPerfumeReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Reactor/TotalPerfumeReactor.swift
@@ -1,0 +1,90 @@
+//
+//  TotalPerfumeReactor.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/28.
+//
+
+import Foundation
+import ReactorKit
+
+class TotalPerfumeReactor: Reactor {
+    
+    enum Action {
+        
+    }
+    
+    enum Mutation {
+        
+    }
+    
+    struct State {
+        var section: [TotalPerfumeSection]
+    }
+    
+    var initialState: State
+    
+    init(_ listType: Int) {
+        initialState = State(section: TotalPerfumeReactor.reqeustPerfumeList(listType))
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        
+    }
+}
+
+extension TotalPerfumeReactor {
+    
+    static func reqeustPerfumeList(_ listType: Int) -> [TotalPerfumeSection]{
+        
+        let perfumeList: [Perfume] = [
+            Perfume(
+                perfumeId: 1,
+                titleName: "조말론",
+                content: "우드세이지 앤 씨솔트",
+                image: UIImage(named: "jomalon")!,
+                isLikePerfume: false),
+            Perfume(
+                perfumeId: 2,
+                titleName: "조말론",
+                content: "우드세이지 앤 씨솔트",
+                image: UIImage(named: "jomalon")!,
+                isLikePerfume: false),
+            Perfume(
+                perfumeId: 3,
+                titleName: "조말론",
+                content: "우드세이지 앤 씨솔트",
+                image: UIImage(named: "jomalon")!,
+                isLikePerfume: false),
+            Perfume(
+                perfumeId: 4,
+                titleName: "조말론",
+                content: "우드세이지 앤 씨솔트",
+                image: UIImage(named: "jomalon")!,
+                isLikePerfume: false),
+            Perfume(
+                perfumeId: 5,
+                titleName: "조말론",
+                content: "우드세이지 앤 씨솔트",
+                image: UIImage(named: "jomalon")!,
+                isLikePerfume: false),
+            Perfume(
+                perfumeId: 6,
+                titleName: "조말론",
+                content: "우드세이지 앤 씨솔트",
+                image: UIImage(named: "jomalon")!,
+                isLikePerfume: false),
+            Perfume(
+                perfumeId: 7,
+                titleName: "조말론",
+                content: "우드세이지 앤 씨솔트",
+                image: UIImage(named: "jomalon")!,
+                isLikePerfume: false)]
+        
+        return [TotalPerfumeSection.first(perfumeList.map { TotalPerfumeSectionItem.perfumeList($0) })]
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Reactor/TotalPerfumeReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/Reactor/TotalPerfumeReactor.swift
@@ -32,7 +32,10 @@ class TotalPerfumeReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .didTapItem(let perfume):
-            return .just(.setSelectedItem(perfume))
+            return .concat([
+                .just(.setSelectedItem(perfume)),
+                .just(.setSelectedItem(nil))
+            ])
         }
     }
     
@@ -96,6 +99,6 @@ extension TotalPerfumeReactor {
                 image: UIImage(named: "jomalon")!,
                 isLikePerfume: false)]
         
-        return [TotalPerfumeSection.first(perfumeList.map { TotalPerfumeSectionItem.perfumeList($0) })]
+        return [TotalPerfumeSection.first(perfumeList.map { TotalPerfumeSectionItem.perfumeList(BrandDetailCellReactor($0)) })]
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/ViewContorller/TotalPerfumeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/ViewContorller/TotalPerfumeViewController.swift
@@ -6,9 +6,24 @@
 //
 
 import UIKit
+import SnapKit
+import Then
+import ReactorKit
+import RxSwift
+import RxCocoa
+import RxDataSources
 
-class TotalPerfumeViewController: UIViewController {
-
+class TotalPerfumeViewController: UIViewController, View {
+    typealias Reactor = TotalPerfumeReactor
+    
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+    var dataSource: RxCollectionViewSectionedReloadDataSource<TotalPerfumeSection>!
+    // MARK: - UI Component
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()).then {
+        $0.register(BrandDetailCollectionViewCell.self, forCellWithReuseIdentifier: BrandDetailCollectionViewCell.identifier)
+    }
+    
     // MARK: - Life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -19,9 +34,64 @@ class TotalPerfumeViewController: UIViewController {
 
 extension TotalPerfumeViewController {
     
+    // MARK: - bind
+    
+    func bind(reactor: TotalPerfumeReactor) {
+        configureDataSource()
+        
+        // MARK: - Action
+        
+        
+        // MARK: - State
+        reactor.state
+            .map { $0.section }
+            .bind(to: collectionView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+    }
+    
     // MARK: - Configure
     func configureUI() {
         view.backgroundColor = .white
+        
+        view.addSubview(collectionView)
+        
+        collectionView.rx.setDelegate(self)
+            .disposed(by: disposeBag)
+        
+        collectionView.snp.makeConstraints {
+            $0.top.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+        }
+    }
+    
+    func configureDataSource() {
+        dataSource = RxCollectionViewSectionedReloadDataSource<TotalPerfumeSection>(configureCell: { _, collectionView, indexPath, item in
+            switch item {
+            case .perfumeList(let perfume):
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BrandDetailCollectionViewCell.identifier, for: indexPath) as? BrandDetailCollectionViewCell else { return UICollectionViewCell() }
+                
+                cell.reactor = BrandDetailCellReactor(perfume)
+                
+                return cell
+            }
+        })
+    }
+}
+
+extension TotalPerfumeViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = (UIScreen.main.bounds.width - 28) / 2
+        let heigth = width + 82
+        
+        return CGSize(width: width, height: heigth)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return 8
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 16, left: 10, bottom: 0, right: 10)
     }
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/ViewContorller/TotalPerfumeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/ViewContorller/TotalPerfumeViewController.swift
@@ -85,10 +85,10 @@ extension TotalPerfumeViewController {
     func configureDataSource() {
         dataSource = RxCollectionViewSectionedReloadDataSource<TotalPerfumeSection>(configureCell: { _, collectionView, indexPath, item in
             switch item {
-            case .perfumeList(let perfume):
+            case .perfumeList(let reactor):
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BrandDetailCollectionViewCell.identifier, for: indexPath) as? BrandDetailCollectionViewCell else { return UICollectionViewCell() }
                 
-                cell.reactor = BrandDetailCellReactor(perfume)
+                cell.reactor = reactor
                 
                 return cell
             }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/ViewContorller/TotalPerfumeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/ViewContorller/TotalPerfumeViewController.swift
@@ -41,12 +41,30 @@ extension TotalPerfumeViewController {
         
         // MARK: - Action
         
+        // collectionView - item 클릭
+        collectionView.rx.modelSelected(TotalPerfumeSectionItem.self)
+            .map { Reactor.Action.didTapItem($0.perfume)}
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         
         // MARK: - State
+        
+        // collectionView 바인딩
         reactor.state
             .map { $0.section }
             .bind(to: collectionView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
+        
+        // item 클릭 시 향수 상세 화면으로 이동
+        reactor.state
+            .map { $0.selectedItem }
+            .distinctUntilChanged()
+            .compactMap { $0 }
+            .bind(onNext: {
+                self.presentDatailViewController($0.perfumeId)
+            })
+            .disposed(by: disposeBag)
+                
     }
     
     // MARK: - Configure

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/ViewContorller/TotalPerfumeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/TotalPerfume/ViewContorller/TotalPerfumeViewController.swift
@@ -1,0 +1,28 @@
+//
+//  TotalPerfumeViewController.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/03/28.
+//
+
+import UIKit
+
+class TotalPerfumeViewController: UIViewController {
+
+    // MARK: - Life cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        self.setBackItemNaviBar("전체보기")
+    }
+}
+
+extension TotalPerfumeViewController {
+    
+    // MARK: - Configure
+    func configureUI() {
+        view.backgroundColor = .white
+    }
+}
+
+


### PR DESCRIPTION


https://user-images.githubusercontent.com/48830320/228466877-5d403fc1-da75-4694-b1a1-e5eaf10a11a0.mp4



### 이슈번호
#58 

### 구현/추가사항
- 화면에 Cell은 이전에 구현해뒀던 BrandDetailCollectionViewCell을 사용해서 작업했습니다. 이렇게 다른 뷰컨에서 재사용되는 Cell은 Cell 이름을 전체적으로 통용되도록 나중에 수정하겠습니다.
- 각 섹션 Reactor의 state에 listType을 설정해서 나중에 API를 호출할 때 해당 listType을 가지고 호출하도록 해놨습니다.
- 기존에 SectionModel의 TotalPerfumeSectionItem에 Perfume구조체를 전달했는데 해당 방식으로 cell을 설정하니 화면 이동 시 처음에 Reactor에서 받아온 데이터값으로만 cell을 보여줘서 cell reactor의 state가 업데이트될 때 다시 화면 이동하면 처음 받아온 데이터로 돌아오는 현상이 있어서 TotalPerfumeSectionItem에 reactor을 전달하는 것으로 수정했습니다. 
 