### PR TITLE
[Feat] 좋아요 페이지 기능 구현

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -144,7 +144,7 @@ extension UIViewController {
             self.navigationItem.leftBarButtonItems = [backButton]
         }
         
-        self.navigationItem.title = title
+        self.setNavigationBarTitle(title)
         
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = color

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Model/HPediaBrandData.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Model/HPediaBrandData.swift
@@ -1,0 +1,9 @@
+//
+//  HPediaTagData.swift
+//  HMOA_iOS
+//
+//  Created by 정지훈 on 2023/04/05.
+//
+
+import Foundation
+

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Model/HPediaGuideData.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Model/HPediaGuideData.swift
@@ -1,0 +1,37 @@
+//
+//  GuideData.swift
+//  HMOA_iOS
+//
+//  Created by 정지훈 on 2023/04/05.
+//
+
+import Foundation
+
+struct HPediaGuideData {
+    var title: String
+    var content: String
+}
+
+extension HPediaGuideData {
+    static let list =
+    [
+        GuideData(title: "용어",
+                  content:
+                  """
+                  Top notes
+                  탑노트란?
+                  """),
+        GuideData(title: "브랜드",
+                  content:
+                  """
+                  Chanel
+                  샤넬
+                  """),
+        GuideData(title: "노트",
+                  content:
+                  """
+                  woody
+                  우디
+                  """)
+    ]
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Model/HPediaGuideSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Model/HPediaGuideSection.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  HMOA_iOS
+//
+//  Created by 정지훈 on 2023/04/05.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Model/HPediaTagSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Model/HPediaTagSection.swift
@@ -1,0 +1,8 @@
+//
+//  HPediaTagSection.swift
+//  HMOA_iOS
+//
+//  Created by 정지훈 on 2023/04/05.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Reactor/HPediaReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Reactor/HPediaReactor.swift
@@ -1,0 +1,8 @@
+//
+//  HPediaReactor.swift
+//  HMOA_iOS
+//
+//  Created by 정지훈 on 2023/04/05.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/View/GuideCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/View/GuideCell.swift
@@ -1,0 +1,12 @@
+//
+//  GuideCell.swift
+//  HMOA_iOS
+//
+//  Created by 정지훈 on 2023/04/04.
+//
+
+import UIKit
+
+class GuideCell: UICollectionViewCell {
+    
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/View/HPediaTagCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/View/HPediaTagCell.swift
@@ -1,0 +1,45 @@
+//
+//  TagCell.swift
+//  HMOA_iOS
+//
+//  Created by 정지훈 on 2023/04/05.
+//
+
+import UIKit
+
+class TagCell: UITableViewCell {
+
+    let nameLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard, size: 20, color: .black)
+    }
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super .init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setUpUI()
+        setAddView()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+
+    //MARK: - SetUp
+    private func setUpUI() {
+        contentView.backgroundColor = .white
+    }
+    
+    private func setAddView() {
+        contentView.addSubview(nameLabel)
+    }
+    
+    private func setConstraints() {
+        nameLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(16)
+            make.centerY.equalToSuperview()
+        }
+    }
+
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/Model/LikeCardModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/Model/LikeCardModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct CardData {
+    let id: Int
     let brandName: String
     let korPerpumeName: String
     let engPerpumeName: String
@@ -17,25 +18,30 @@ struct CardData {
 
 extension CardData {
     static let items: [CardData] = [
-        CardData(brandName: "조말론 런던",
-                  korPerpumeName: "무드 세이지 앤 씨 솔트 코롱",
-                  engPerpumeName: "Wood Sage & Sea Salt Cologne",
-                  price: 218000),
-        CardData(brandName: "조말론 런던",
-                  korPerpumeName: "무드 세이지 앤 씨 솔트 코롱",
-                  engPerpumeName: "Wood Sage & Sea Salt Cologne",
-                  price: 228000),
-        CardData(brandName: "조말론 런던",
-                  korPerpumeName: "무드 세이지 앤 씨 솔트 코롱",
-                  engPerpumeName: "Wood Sage & Sea Salt Cologne",
-                  price: 238000),
-        CardData(brandName: "조말론 런던",
-                  korPerpumeName: "무드 세이지 앤 씨 솔트 코롱",
-                  engPerpumeName: "Wood Sage & Sea Salt Cologne",
-                  price: 248000),
-        CardData(brandName: "조말론 런던",
-                  korPerpumeName: "무드 세이지 앤 씨 솔트 코롱",
-                  engPerpumeName: "Wood Sage & Sea Salt Cologne",
-                  price: 218000)
+        CardData(id: 1,
+                 brandName: "조말론 런던",
+                 korPerpumeName: "무드 세이지 앤 씨 솔트 코롱",
+                 engPerpumeName: "Wood Sage & Sea Salt Cologne",
+                 price: 218000),
+        CardData(id: 2,
+                 brandName: "조말론 런던",
+                 korPerpumeName: "무드 세이지 앤 씨 솔트 코롱",
+                 engPerpumeName: "Wood Sage & Sea Salt Cologne",
+                 price: 228000),
+        CardData(id: 3,
+                 brandName: "조말론 런던",
+                 korPerpumeName: "무드 세이지 앤 씨 솔트 코롱",
+                 engPerpumeName: "Wood Sage & Sea Salt Cologne",
+                 price: 238000),
+        CardData(id: 4,
+                 brandName: "조말론 런던",
+                 korPerpumeName: "무드 세이지 앤 씨 솔트 코롱",
+                 engPerpumeName: "Wood Sage & Sea Salt Cologne",
+                 price: 248000),
+        CardData(id: 5,
+                 brandName: "조말론 런던",
+                 korPerpumeName: "무드 세이지 앤 씨 솔트 코롱",
+                 engPerpumeName: "Wood Sage & Sea Salt Cologne",
+                 price: 218000)
         ]
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/Model/LikeListModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/Model/LikeListModel.swift
@@ -8,39 +8,40 @@
 import Foundation
 
 struct ListData {
+    let id: Int
     let imgName: String
 }
 
 
 extension ListData {
     static let items: [ListData] = [
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon"),
-    ListData(imgName: "jomalon")
+        ListData(id: 1, imgName: "jomalon"),
+        ListData(id: 2, imgName: "jomalon"),
+        ListData(id: 3, imgName: "jomalon"),
+        ListData(id: 4, imgName: "jomalon"),
+        ListData(id: 5, imgName: "jomalon"),
+        ListData(id: 6, imgName: "jomalon"),
+        ListData(id: 7, imgName: "jomalon"),
+        ListData(id: 8, imgName: "jomalon"),
+        ListData(id: 9, imgName: "jomalon"),
+        ListData(id: 10, imgName: "jomalon"),
+        ListData(id: 11, imgName: "jomalon"),
+        ListData(id: 12, imgName: "jomalon"),
+        ListData(id: 13, imgName: "jomalon"),
+        ListData(id: 14, imgName: "jomalon"),
+        ListData(id: 15, imgName: "jomalon"),
+        ListData(id: 16, imgName: "jomalon"),
+        ListData(id: 17, imgName: "jomalon"),
+        ListData(id: 18, imgName: "jomalon"),
+        ListData(id: 19, imgName: "jomalon"),
+        ListData(id: 20, imgName: "jomalon"),
+        ListData(id: 21, imgName: "jomalon"),
+        ListData(id: 22, imgName: "jomalon"),
+        ListData(id: 23, imgName: "jomalon"),
+        ListData(id: 24, imgName: "jomalon"),
+        ListData(id: 25, imgName: "jomalon"),
+        ListData(id: 26, imgName: "jomalon"),
+        ListData(id: 27, imgName: "jomalon"),
+        ListData(id: 28, imgName: "jomalon")
     ]
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/Reactor/LikeReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/Reactor/LikeReactor.swift
@@ -17,11 +17,14 @@ class LikeReactor: Reactor {
     }
     
     enum Action {
+        case didTapListItem(IndexPath)
+        case didTapCardItem(IndexPath)
         case didTapCardButton
         case didTapListButton
     }
     
     enum Mutation {
+        case setSelectedIndexPath(IndexPath?)
         case setShowCardCollectionView(Bool)
         case setShowListCollectionView(Bool)
     }
@@ -31,6 +34,7 @@ class LikeReactor: Reactor {
         var listSections: [ListSection] = [ListSection(items: ListData.items)]
         var isSelectedCard: Bool = true
         var isSelectedList: Bool = false
+        var selectedPerpumeId: Int? = nil
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -39,9 +43,15 @@ class LikeReactor: Reactor {
             return .just(.setShowCardCollectionView(true))
         case .didTapListButton:
             return .just(.setShowListCollectionView(true))
+        case .didTapListItem(let indexPath),
+                .didTapCardItem(let indexPath):
+            return .concat ([
+                .just(.setSelectedIndexPath(indexPath)),
+                .just(.setSelectedIndexPath(nil))
+            ])
         }
     }
-
+    
     func reduce(state: State, mutation: Mutation) -> State {
         var state = state
         
@@ -52,6 +62,13 @@ class LikeReactor: Reactor {
         case .setShowCardCollectionView(let isSelected):
             state.isSelectedCard = isSelected
             state.isSelectedList = !isSelected
+        case .setSelectedIndexPath(let indexPath):
+            guard let indexPath = indexPath
+            else {
+                state.selectedPerpumeId = nil
+                return state
+            }
+            state.selectedPerpumeId = state.listSections[indexPath.section].items[indexPath.item].id
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/View/LikeCardCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/View/LikeCardCell.swift
@@ -97,7 +97,7 @@ class LikeCardCell: UICollectionViewCell {
         
         $0.backgroundColor = .white
         $0.layer.borderWidth = 1
-        $0.layer.cornerRadius = 10
+        $0.layer.cornerRadius = 5
         $0.layer.masksToBounds = true
         $0.layer.shadowOpacity = 0.2
         $0.layer.shadowOffset = CGSize(width: 4, height: 4)
@@ -125,7 +125,7 @@ class LikeCardCell: UICollectionViewCell {
     override func layoutSubviews() {
         
         contentView.layer.borderWidth = 1
-        contentView.layer.cornerRadius = 10
+        contentView.layer.cornerRadius = 5
         contentView.layer.masksToBounds = true
         
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/ViewController/LikeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/ViewController/LikeViewController.swift
@@ -67,7 +67,7 @@ class LikeViewController: UIViewController {
     //MARK: - SetUp
     private func setUpUI() {
         view.backgroundColor = UIColor.white
-        setNavigationBarTitle(title: "저장",
+        setNavigationBarTitle(title: "",
                               color: .white,
                               isHidden: true,
                               isScroll: false)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/ViewController/LikeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/ViewController/LikeViewController.swift
@@ -67,10 +67,8 @@ class LikeViewController: UIViewController {
     //MARK: - SetUp
     private func setUpUI() {
         view.backgroundColor = UIColor.white
-        setNavigationBarTitle(title: "",
-                              color: .white,
-                              isHidden: true,
-                              isScroll: false)
+        setNavigationColor()
+        setNavigationBarTitle("저장")
     }
     
     private func setAddView() {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/ViewController/LikeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Like/ViewController/LikeViewController.swift
@@ -83,24 +83,25 @@ class LikeViewController: UIViewController {
     private func setConstraints() {
         cardButton.snp.makeConstraints { make in
             make.trailing.equalToSuperview().inset(17.5)
-            make.bottom.equalTo(cardCollectionView.snp.top).offset(-23)
-            make.height.equalTo(20)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(19)
+            make.height.equalTo(18)
         }
         
         listButton.snp.makeConstraints { make in
             make.trailing.equalTo(cardButton.snp.leading).offset(-13)
-            make.bottom.equalTo(cardCollectionView.snp.top).offset(-23)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(19)
             make.height.equalTo(18)
         }
         
         cardCollectionView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(357)
-            make.centerY.equalToSuperview()
+            make.height.equalTo(354).priority(751)
+            make.top.equalTo(listButton.snp.bottom).offset(23)
+            make.bottom.equalToSuperview()
         }
         
         listCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(listButton.snp.bottom).offset(19)
+            make.top.equalTo(listButton.snp.bottom).offset(23)
             make.leading.trailing.equalToSuperview().inset(8)
             make.bottom.equalToSuperview()
         }
@@ -163,6 +164,15 @@ class LikeViewController: UIViewController {
     private func bind(reactor: LikeReactor) {
         
         //Input
+        cardCollectionView.rx.itemSelected
+            .map { LikeReactor.Action.didTapCardItem($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        listCollectionView.rx.itemSelected
+            .map { LikeReactor.Action.didTapListItem($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         
         //카드버튼 터치 이벤트
         cardButton.rx.tap
@@ -174,6 +184,8 @@ class LikeViewController: UIViewController {
             .map { LikeReactor.Action.didTapListButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        //Output
         
         //cardCollectionView Binding
         reactor.state
@@ -213,6 +225,13 @@ class LikeViewController: UIViewController {
                 
             })
             .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.selectedPerpumeId }
+            .distinctUntilChanged()
+            .bind(onNext: {
+                self.presentDatailViewController($0)
+            }).disposed(by: disposeBag)
       
     }
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/75370733/229663708-d17c07eb-1cbc-4ba9-927e-beaba60df9ab.mp4
### 이슈 번호
#65 

### 구현/추가 사항
- LikeVC 오토레이아웃 피그마에 맞게 조정했습니다.
- 현재 더미 값으로 테스트 하느라 카드형식과 리스트 형식 모델이 따로 있어 제품이 더 많은 리스트 형식 기반으로 임시 구현했고 추후에 api연동 후 모델 하나로 통일 하겠습니다.
- 피그마에 모든 네비게이션 타이틀 크기가 20이라 ViewController++에 setNavigationBarTitle에 폰트 크기를 20으로 되게끔 수정했습니다.