### PR TITLE
[Feat] 마이페이지 API 및 기능 수정

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		2CD0235C2A07D68F00459801 /* ChangeNicknameReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD0235B2A07D68F00459801 /* ChangeNicknameReactor.swift */; };
 		2CD0235E2A080D4500459801 /* MyProfileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD0235D2A080D4500459801 /* MyProfileType.swift */; };
 		2CD023632A092A5200459801 /* UserYearService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD023622A092A5200459801 /* UserYearService.swift */; };
+		2CE32FB12A13CBAA00BEF7A8 /* MemberCellReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE32FB02A13CBAA00BEF7A8 /* MemberCellReactor.swift */; };
 		CA03C23E29EBED6C00FA0D2C /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA03C23D29EBED6C00FA0D2C /* LoginManager.swift */; };
 		CA051CB0297FDA0F001865F5 /* UserInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA051CAF297FDA0F001865F5 /* UserInformationViewController.swift */; };
 		CA0DB39129DBD67B0091DCB2 /* GuideCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0DB39029DBD67B0091DCB2 /* GuideCell.swift */; };
@@ -309,6 +310,7 @@
 		2CD0235B2A07D68F00459801 /* ChangeNicknameReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNicknameReactor.swift; sourceTree = "<group>"; };
 		2CD0235D2A080D4500459801 /* MyProfileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileType.swift; sourceTree = "<group>"; };
 		2CD023622A092A5200459801 /* UserYearService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserYearService.swift; sourceTree = "<group>"; };
+		2CE32FB02A13CBAA00BEF7A8 /* MemberCellReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberCellReactor.swift; sourceTree = "<group>"; };
 		4E20A0B5EE1007CE84ADB6F6 /* Pods-HMOA_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HMOA_iOS.release.xcconfig"; path = "Target Support Files/Pods-HMOA_iOS/Pods-HMOA_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		59F6053BF5AC3DBACFB3FCD8 /* Pods-HMOA_iOS-HMOA_iOSUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HMOA_iOS-HMOA_iOSUITests.release.xcconfig"; path = "Target Support Files/Pods-HMOA_iOS-HMOA_iOSUITests/Pods-HMOA_iOS-HMOA_iOSUITests.release.xcconfig"; sourceTree = "<group>"; };
 		A266DA0D7E24CB1ED544B374 /* Pods_HMOA_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HMOA_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -772,6 +774,7 @@
 			isa = PBXGroup;
 			children = (
 				2C464E4829CDB16A00A07658 /* MyPageReactor.swift */,
+				2CE32FB02A13CBAA00BEF7A8 /* MemberCellReactor.swift */,
 			);
 			path = Reactor;
 			sourceTree = "<group>";
@@ -1820,6 +1823,7 @@
 				2C464E5F29CDDCDF00A07658 /* OpenSourceViewController.swift in Sources */,
 				2C464E5929CDDC8500A07658 /* MyLogViewController.swift in Sources */,
 				2CA155B02A039AD100D7B0C0 /* MemberAddress.swift in Sources */,
+				2CE32FB12A13CBAA00BEF7A8 /* MemberCellReactor.swift in Sources */,
 				2C4CDC4729C770D900676163 /* Brand.swift in Sources */,
 				2C710EFC297C15DF006BE23B /* MyPageCell.swift in Sources */,
 				2C39AA7B29705524000C6F71 /* UIColor++Extenstions.swift in Sources */,
@@ -2017,13 +2021,14 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = WBG9V97XP4;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HMOA_iOS/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2049,7 +2054,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = WBG9V97XP4;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_ONLY_ACTIVE_RESOURCES = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HMOA_iOS/Resource/Info.plist;
@@ -2057,6 +2062,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/Int++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/Int++Extenstions.swift
@@ -15,4 +15,15 @@ extension Int {
 
         return "₩" + numberFormatter.string(from: NSNumber(value: self))! + "~"
     }
+    
+    /// 나이로 태어난 년도 구하는 함수
+    func ageToYear() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy"
+        dateFormatter.locale = Locale(identifier: "ko")
+        
+        let year = dateFormatter.string(from: Date())
+        
+        return String(Int(year)! - self + 1)
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct Member: Codable {
-    let age: Int
-    let imgUrl: String?
-    let memberId: Int
-    let nickname: String
-    let provider: String
-    let sex: Bool
+    var age: Int
+    var imgUrl: String
+    var memberId: Int
+    var nickname: String
+    var provider: String
+    var sex: Bool
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/UserInformation/Reactor/ChangeSexReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/UserInformation/Reactor/ChangeSexReactor.swift
@@ -11,6 +11,7 @@ import RxCocoa
 
 class ChangeSexReactor: Reactor {
     let initialState: State
+    var service: UserServiceProtocol
     
     enum Action {
         case didTapWomanButton
@@ -32,8 +33,9 @@ class ChangeSexReactor: Reactor {
         var sexType: Bool? = false
     }
     
-    init(_ currentType: Bool = false) {
-        initialState = currentType ? State(isCheckedMan: true) : State(isCheckedWoman: true)
+    init(_ currentType: Bool = false, service: UserServiceProtocol) {
+        self.initialState = currentType ? State(isCheckedMan: true) : State(isCheckedWoman: true)
+        self.service = service
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -49,7 +51,7 @@ class ChangeSexReactor: Reactor {
             
             return .concat([
                 ChangeSexReactor.patchUserSex(sex),
-                .just(.setPopMyPage(false))
+                service.updateUserSex(to: sex).map { _ in .setPopMyPage(false)}
             ])
         }
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/UserInformation/Reactor/ChangeSexReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/UserInformation/Reactor/ChangeSexReactor.swift
@@ -32,8 +32,8 @@ class ChangeSexReactor: Reactor {
         var sexType: Bool? = false
     }
     
-    init() {
-        initialState = State()
+    init(_ currentType: Bool = false) {
+        initialState = currentType ? State(isCheckedMan: true) : State(isCheckedWoman: true)
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -80,11 +80,8 @@ class ChangeSexReactor: Reactor {
 extension ChangeSexReactor {
     
     static func patchUserSex(_ type: Bool) -> Observable<Mutation> {
-        
-        let sex = type ? "남성" : "여성"
-        
-        //api request형식이 바껴서 임시로 true로 설정해 놨습니다.
-        return MemberAPI.updateSex(params: ["sex": true])
+
+        return MemberAPI.updateSex(params: ["sex": type])
             .catch { _ in .empty() }
             .flatMap { response -> Observable<Mutation> in
                 return .just(.setPopMyPage(true))

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/UserInformation/Reactor/ChangeYearReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/UserInformation/Reactor/ChangeYearReactor.swift
@@ -13,7 +13,8 @@ import RxCocoa
 class ChangeYearReactor: Reactor {
     var initialState: State
     var service: UserYearServiceProtocol
-
+    var userService: UserServiceProtocol
+    
     enum Action {
         case didTapChoiceYearButton
         case didTapChangeButton
@@ -34,9 +35,10 @@ class ChangeYearReactor: Reactor {
         var selectedYear: String? = nil
     }
     
-    init(service: UserYearServiceProtocol, selectedYear: String? = nil) {
+    init(service: UserYearServiceProtocol, selectedYear: String? = nil, userService: UserServiceProtocol? = nil) {
         self.initialState = State(selectedYear: selectedYear)
         self.service = service
+        self.userService = userService!
     }
     
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
@@ -65,7 +67,8 @@ class ChangeYearReactor: Reactor {
             
             return .concat([
                 ChangeYearReactor.patchUserYear(year),
-                .just(.setPopMyPage(false))
+                userService.updateUserAge(to: year).map { _ in .setPopMyPage(false)},
+                
             ])
             
         case .didChangeSelectedYear(let year):

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/UserInformation/Reactor/ChangeYearReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/UserInformation/Reactor/ChangeYearReactor.swift
@@ -34,8 +34,8 @@ class ChangeYearReactor: Reactor {
         var selectedYear: String? = nil
     }
     
-    init(service: UserYearServiceProtocol) {
-        self.initialState = State()
+    init(service: UserYearServiceProtocol, selectedYear: String? = nil) {
+        self.initialState = State(selectedYear: selectedYear)
         self.service = service
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Model/MyPageSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Model/MyPageSection.swift
@@ -8,13 +8,13 @@
 import RxDataSources
 
 enum MyPageSection {
-    case first(MyPageSectionItem)
-    case etc([MyPageSectionItem])
+    case memberSection(MyPageSectionItem)
+    case otherSection([MyPageSectionItem])
 }
 
 enum MyPageSectionItem {
-    case userInfo(UserInfo)
-    case etc(String)
+    case memberCell(Member)
+    case otherCell(String)
 }
 
 extension MyPageSection: SectionModelType {
@@ -23,19 +23,14 @@ extension MyPageSection: SectionModelType {
     
     var items: [MyPageSectionItem] {
         switch self {
-        case .first(let item):
+        case .memberSection(let item):
             return [item]
-        case .etc(let items):
+        case .otherSection(let items):
             return items
         }
     }
     
     init(original: MyPageSection, items: [MyPageSectionItem]) {
-        switch original {
-        case .first:
-            self = .first(items.first!)
-        case .etc:
-            self = .etc(items)
-        }
+        self = original
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Model/MyPageSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Model/MyPageSection.swift
@@ -13,7 +13,7 @@ enum MyPageSection {
 }
 
 enum MyPageSectionItem {
-    case memberCell(Member)
+    case memberCell(MemberCellReactor)
     case otherCell(String)
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Reactor/ChangeNicknameReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Reactor/ChangeNicknameReactor.swift
@@ -29,13 +29,14 @@ class ChangeNicknameReactor: Reactor {
         var isDuplicate: Bool? = nil
         var isEnable: Bool = false
         var isTapReturn: Bool = false
+        var currentNickname: String
         var nickname: String? = nil
         var nicknameResponse: Response? = nil
         var shouldDismissed: Bool = false
     }
     
-    init(service: UserServiceProtocol) {
-        self.initialState = State()
+    init(service: UserServiceProtocol, currentNickname: String) {
+        self.initialState = State(currentNickname: currentNickname)
         self.service = service
     }
     
@@ -90,8 +91,3 @@ class ChangeNicknameReactor: Reactor {
     }
 }
 
-extension ChangeNicknameReactor {
-//    func reactorForUserInformation() -> UserInformationReactor {
-//        return UserInformationReactor(service: service)
-//    }
-}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Reactor/MyProfileReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Reactor/MyProfileReactor.swift
@@ -81,4 +81,8 @@ extension MyProfileReactor {
     func reactorForChangeYear() -> ChangeYearReactor {
         return ChangeYearReactor(service: UserYearService(), selectedYear: currentState.member.age.ageToYear())
     }
+    
+    func reactorForChangeSex() -> ChangeSexReactor {
+        return ChangeSexReactor(currentState.member.sex)
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Reactor/MyProfileReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Reactor/MyProfileReactor.swift
@@ -77,4 +77,8 @@ extension MyProfileReactor {
     func reactorForChangeNickname() -> ChangeNicknameReactor {
         return ChangeNicknameReactor(service: service, currentNickname: currentState.member.nickname)
     }
+    
+    func reactorForChangeYear() -> ChangeYearReactor {
+        return ChangeYearReactor(service: UserYearService(), selectedYear: currentState.member.age.ageToYear())
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Reactor/MyProfileReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Reactor/MyProfileReactor.swift
@@ -22,12 +22,14 @@ class MyProfileReactor: Reactor {
     
     struct State {
         var sections: [MyProfileSection]
+        var member: Member
         var presentVC: MyProfileType? = nil
     }
     
-    init(service: UserServiceProtocol) {
+    init(service: UserServiceProtocol, member: Member) {
         self.initialState = State(
-            sections: MyProfileReactor.setUpSection()
+            sections: MyProfileReactor.setUpSection(),
+            member: member
         )
         
         self.service = service
@@ -73,6 +75,6 @@ extension MyProfileReactor {
     }
     
     func reactorForChangeNickname() -> ChangeNicknameReactor {
-        return ChangeNicknameReactor(service: service)
+        return ChangeNicknameReactor(service: service, currentNickname: currentState.member.nickname)
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Service/UserService.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Service/UserService.swift
@@ -10,6 +10,8 @@ import RxSwift
 enum UserEvent {
     case updateNickname(content: String)
     case updateImage(content: UIImage)
+    case updateUserAge(content: Int)
+    case updateUserSex(content: Bool)
 }
 
 protocol UserServiceProtocol {
@@ -18,6 +20,10 @@ protocol UserServiceProtocol {
     func updateUserNickname(to nickname: String) -> Observable<String>
     
     func updateUserImage(to image: UIImage) -> Observable<UIImage>
+    
+    func updateUserAge(to year: String) -> Observable<Int>
+    
+    func updateUserSex(to sex: Bool) -> Observable<Bool>
 }
 
 
@@ -33,6 +39,17 @@ class UserService: UserServiceProtocol {
     func updateUserImage(to image: UIImage) -> Observable<UIImage> {
         event.onNext(.updateImage(content: image))
         return .just(image)
+    }
+    
+    func updateUserAge(to year: String) -> Observable<Int> {
+        let age = 2024 - Int(year)!
+        event.onNext(.updateUserAge(content: age))
+        return .just(age)
+    }
+    
+    func updateUserSex(to sex: Bool) -> Observable<Bool> {
+        event.onNext(.updateUserSex(content: sex))
+        return .just(sex)
     }
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Viewcontroller/ChangeNicknameViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Viewcontroller/ChangeNicknameViewController.swift
@@ -95,7 +95,7 @@ extension ChangeNicknameViewController {
                 self.nicknameView.nicknameTextField.resignFirstResponder()
             }).disposed(by: disposeBag)
         
-        //연도 VC로 화면 전환
+        // 이전 화면으로 pop
         reactor.state
             .map { $0.nicknameResponse }
             .distinctUntilChanged()
@@ -104,6 +104,12 @@ extension ChangeNicknameViewController {
             .bind(onNext: popViewController)
             .disposed(by: disposeBag)
             
+        // 기존 닉네임 바인딩
+        reactor.state
+            .map { $0.currentNickname }
+            .distinctUntilChanged()
+            .bind(to: nicknameView.nicknameTextField.rx.text)
+            .disposed(by: disposeBag)
     }
     
     // MARK: - configure

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Viewcontroller/MyProfileViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Viewcontroller/MyProfileViewController.swift
@@ -143,7 +143,7 @@ extension MyProfileViewController {
         case .sex:
             
             let changeSexVC = ChangeSexViewController()
-            changeSexVC.reactor = ChangeSexReactor()
+            changeSexVC.reactor = reactor.reactorForChangeSex()
             
             self.navigationController?.pushViewController(changeSexVC, animated: true)
         }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Viewcontroller/MyProfileViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Viewcontroller/MyProfileViewController.swift
@@ -136,8 +136,9 @@ extension MyProfileViewController {
             
             self.navigationController?.pushViewController(changeNicknameVC, animated: true)
         case .year:
-            let changeYearVC = ChangeYearViewConroller(reactor: ChangeYearReactor(service: UserYearService()))
+            let changeYearReactor = reactor.reactorForChangeYear()
             
+            let changeYearVC = ChangeYearViewConroller(reactor: changeYearReactor)
             self.navigationController?.pushViewController(changeYearVC, animated: true)
         case .sex:
             

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MemberCellReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MemberCellReactor.swift
@@ -1,0 +1,29 @@
+//
+//  MemberCellReactor.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/05/16.
+//
+
+import ReactorKit
+
+class MemberCellReactor: Reactor {
+    
+    var initialState: State
+    
+    enum Action {
+        
+    }
+    
+    enum Mutation {
+        
+    }
+    
+    struct State {
+        var member: Member
+    }
+    
+    init(member: Member) {
+        initialState = State(member: member)
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
@@ -131,7 +131,7 @@ extension MyPageReactor {
                     imgUrl: member.imgUrl,
                     memberId: member.memberId,
                     nickname: member.nickname,
-                    provider: member.provider,
+                    provider: MyPageReactor.providerToKorean(member.provider),
                     sex: member.sex)
                 
                 sections.append(MyPageSection.memberSection(
@@ -144,6 +144,19 @@ extension MyPageReactor {
                     .just(.setSections(sections))
                 ])
             }
+    }
+    
+    static func providerToKorean(_ type: String) -> String {
+        switch type {
+        case "GOOGLE":
+            return "구글 로그인"
+        case "KAKAO":
+            return "카카오 로그인"
+        case "APPLE":
+            return "애플 로그인"
+        default:
+            return ""
+        }
     }
     
     func reactorForMyProfile() -> MyProfileReactor {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
@@ -22,6 +22,8 @@ class MyPageReactor: Reactor {
         case setSections([MyPageSection])
         case setMember(Member)
         case updateNickname(String)
+        case updateAge(Int)
+        case updateSex(Bool)
     }
     
     struct State {
@@ -39,7 +41,6 @@ class MyPageReactor: Reactor {
     init(service: UserServiceProtocol) {
         self.initialState = State()
         self.service = service
-        
     }
     
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
@@ -49,6 +50,10 @@ class MyPageReactor: Reactor {
                 return .just(.updateNickname(nickname))
             case .updateImage(content: _):
                 return .empty()
+            case .updateUserAge(content: let age):
+                return .just(.updateAge(age))
+            case .updateUserSex(content: let sex):
+                return .just(.updateSex(sex))
             }
         }
 
@@ -90,6 +95,12 @@ class MyPageReactor: Reactor {
                 MyPageSection.memberSection(
                     MyPageSectionItem.memberCell(MemberCellReactor(member: state.member)))
             ] + MyPageReactor.setUpOtherSection()
+            
+        case .updateAge(let age):
+            state.member.age = age
+            
+        case .updateSex(let sex):
+            state.member.sex = sex
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
@@ -88,7 +88,7 @@ class MyPageReactor: Reactor {
             
             state.sections = [
                 MyPageSection.memberSection(
-                    MyPageSectionItem.memberCell(state.member))
+                    MyPageSectionItem.memberCell(MemberCellReactor(member: state.member)))
             ] + MyPageReactor.setUpOtherSection()
         }
         
@@ -135,7 +135,7 @@ extension MyPageReactor {
                     sex: member.sex)
                 
                 sections.append(MyPageSection.memberSection(
-                    MyPageSectionItem.memberCell(member)))
+                    MyPageSectionItem.memberCell(MemberCellReactor(member: member))))
                 
                 sections += setUpOtherSection()
                 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
@@ -147,6 +147,6 @@ extension MyPageReactor {
     }
     
     func reactorForMyProfile() -> MyProfileReactor {
-        return MyProfileReactor(service: service)
+        return MyProfileReactor(service: service, member: currentState.member)
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/View/MyPageUserCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/View/MyPageUserCell.swift
@@ -70,9 +70,9 @@ extension MyPageUserCell {
         }
     }
     
-    func updateCell(_ userInfo: UserInfo) {
+    func updateCell(_ member: Member) {
         
-        nickNameLabel.text = userInfo.nickName
-        loginTypeLabel.text = userInfo.loginType
+        nickNameLabel.text = member.nickname
+        loginTypeLabel.text = member.provider
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/View/MyPageUserCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/View/MyPageUserCell.swift
@@ -8,8 +8,13 @@
 import UIKit
 import SnapKit
 import Then
+import ReactorKit
+import Kingfisher
 
-class MyPageUserCell: UITableViewCell {
+class MyPageUserCell: UITableViewCell, View {
+    
+    typealias Reactor = MemberCellReactor
+    var disposeBag = DisposeBag()
     
     // MARK: - identifier
     static let identifier = "MyPageUserCell"
@@ -18,7 +23,7 @@ class MyPageUserCell: UITableViewCell {
 
     lazy var profileImage = UIImageView().then {
         $0.layer.cornerRadius = 16
-        $0.backgroundColor = .customColor(.gray3)
+        $0.contentMode = .scaleAspectFit
     }
     
     lazy var nickNameLabel = UILabel().then {
@@ -44,6 +49,31 @@ class MyPageUserCell: UITableViewCell {
 // MARK: Functions
 
 extension MyPageUserCell {
+    
+    func bind(reactor: MemberCellReactor) {
+        
+        // MARK: - state
+        
+        reactor.state
+            .map { $0.member.nickname }
+            .distinctUntilChanged()
+            .bind(to: nickNameLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.member.imgUrl }
+            .map { URL(string: $0) }
+            .distinctUntilChanged()
+            .bind(onNext: { [weak self] in
+                self?.profileImage.kf.setImage(with: $0)
+            })
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.member.provider }
+            .bind(to: loginTypeLabel.rx.text)
+            .disposed(by: disposeBag)
+    }
     
     // MARK: - Configure
     func configureUI() {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/ViewController/MyPageViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/ViewController/MyPageViewController.swift
@@ -132,7 +132,6 @@ extension MyPageViewController {
             myProfileVC.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(myProfileVC, animated: true)
             
-            print(reactor.currentState.member)
         case .openSource:
             break
         case .policy:

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/ViewController/MyPageViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/ViewController/MyPageViewController.swift
@@ -100,15 +100,15 @@ extension MyPageViewController {
         dataSource = RxTableViewSectionedReloadDataSource<MyPageSection>(configureCell: { _, tableView, indexPath, item in
             
             switch item {
-            case .userInfo(let userInfo):
+            case .memberCell(let member):
                 
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: MyPageUserCell.identifier, for: indexPath) as? MyPageUserCell else { return UITableViewCell() }
                 
-                cell.updateCell(userInfo)
+                cell.updateCell(member)
                 cell.selectionStyle = .none
                 
                 return cell
-            case .etc(let title):
+            case .otherCell(let title):
                 
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: MyPageCell.identifier, for: indexPath) as? MyPageCell else { return UITableViewCell() }
                 
@@ -131,6 +131,8 @@ extension MyPageViewController {
             
             myProfileVC.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(myProfileVC, animated: true)
+            
+            print(reactor.currentState.member)
         case .openSource:
             break
         case .policy:

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/ViewController/MyPageViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/ViewController/MyPageViewController.swift
@@ -100,11 +100,11 @@ extension MyPageViewController {
         dataSource = RxTableViewSectionedReloadDataSource<MyPageSection>(configureCell: { _, tableView, indexPath, item in
             
             switch item {
-            case .memberCell(let member):
+            case .memberCell(let reactor):
                 
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: MyPageUserCell.identifier, for: indexPath) as? MyPageUserCell else { return UITableViewCell() }
                 
-                cell.updateCell(member)
+                cell.reactor = reactor
                 cell.selectionStyle = .none
                 
                 return cell


### PR DESCRIPTION

https://github.com/HMOAA/HMOA_iOS/assets/48830320/22d3d755-8779-40ce-b4ff-e463cbd6d19e



### 이슈번호
#77 

### 구현 / 추가사항
- 바뀐 API를 통해서 사용자 이미지와 사용자 로그인 타입 적용했습니다.
- 사용자 정보 변경화면 진입 시 사용자의 기존 정보가 표시되도록 수정하였습니다.
- '내 정보관리'화면 reactor에서 사용자 정보를 가지고 있도록 수정했고 정보 변경시 transform을 통해서 마이페이지 reactor과 내 정보관리화면 reactor 두 개의 reactor에서 member 정보를 전달받아 state의 member객체값을 수정하도록 했습니다.
- 정보 수정 완료시 alert화면이나 Toast메시지 띄워야될 것 같은데 디자이너분에게 말씀드려야 될 것 같습니다.