### PR TITLE
[Feat] 홈 화면 API 호출 페이징 적용 구현 

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		2CAD9637298E483800974500 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAD9636298E483800974500 /* DetailView.swift */; };
 		2CAD9639298E4C1D00974500 /* PerfumeInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAD9638298E4C1D00974500 /* PerfumeInfoView.swift */; };
 		2CAD9641298E6F6200974500 /* TagListView++Extenstions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAD9640298E6F6200974500 /* TagListView++Extenstions.swift */; };
+		2CC12C7D2A2CCC09003B3A60 /* String++Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC12C7C2A2CCC09003B3A60 /* String++Extension.swift */; };
 		2CD023512A07AEBC00459801 /* NicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD023502A07AEBC00459801 /* NicknameView.swift */; };
 		2CD023552A07B5A500459801 /* ChangeNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD023542A07B5A500459801 /* ChangeNicknameViewController.swift */; };
 		2CD0235A2A07D3CB00459801 /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD023592A07D3CB00459801 /* UserService.swift */; };
@@ -311,6 +312,7 @@
 		2CAD9636298E483800974500 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		2CAD9638298E4C1D00974500 /* PerfumeInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfumeInfoView.swift; sourceTree = "<group>"; };
 		2CAD9640298E6F6200974500 /* TagListView++Extenstions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TagListView++Extenstions.swift"; sourceTree = "<group>"; };
+		2CC12C7C2A2CCC09003B3A60 /* String++Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String++Extension.swift"; sourceTree = "<group>"; };
 		2CD023502A07AEBC00459801 /* NicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameView.swift; sourceTree = "<group>"; };
 		2CD023542A07B5A500459801 /* ChangeNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNicknameViewController.swift; sourceTree = "<group>"; };
 		2CD023592A07D3CB00459801 /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
@@ -762,6 +764,7 @@
 				2C04249E29A67F07009CF0FE /* UIButton++Extenstions.swift */,
 				2C60F21F29BA0F4000595EF4 /* Int++Extenstions.swift */,
 				CA69F39A29DEB2D0004958BB /* CALayer++Extenstions.swift */,
+				2CC12C7C2A2CCC09003B3A60 /* String++Extension.swift */,
 			);
 			path = Extenstions;
 			sourceTree = "<group>";
@@ -1716,6 +1719,7 @@
 				CACA20E429E38BCE009995F3 /* IgnoerData.swift in Sources */,
 				CA360F3A29DD870E00A93873 /* HPediaReactor.swift in Sources */,
 				2C4CDC4029C770D900676163 /* BrandInfo.swift in Sources */,
+				2CC12C7D2A2CCC09003B3A60 /* String++Extension.swift in Sources */,
 				CA5DB81929EAA6F500BE0F79 /* LoginModel.swift in Sources */,
 				2C4041CE29ACD94D009247E7 /* SearchBarContainerView.swift in Sources */,
 				CA34781B29E2DAE300334070 /* HPediaGuideHeaderCell.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/String++Extension.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/String++Extension.swift
@@ -1,0 +1,25 @@
+//
+//  String++Extension.swift
+//  HMOA_iOS
+//
+//  Created by 임현규 on 2023/06/04.
+//
+
+import Foundation
+
+extension String {
+    
+    mutating func changeProvider() {
+
+        switch self {
+        case "GOOGLE":
+            self =  "구글 로그인"
+        case "KAKAO":
+            self = "카카오 로그인"
+        case "APPLE":
+            self = "애플 로그인"
+        default:
+            self = ""
+        }
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Home/HomeAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Home/HomeAPI.swift
@@ -9,12 +9,22 @@ import RxSwift
 
 class HomeAPI {
     
-    static func getHomeData() -> Observable<HomeData> {
+    /// 홈 화면 2개 데이터 값 받아오는 API
+    static func getFirstHomeData() -> Observable<HomeFirstData> {
         return networking(
-            urlStr: HomeAddress.getHomeData.url,
+            urlStr: HomeAddress.getFirstHomeData.url,
             method: .get,
             data: nil,
-            model: HomeData.self)
+            model: HomeFirstData.self)
+    }
+    
+    /// 홈 화면 나머지 데이터 값 받아오는 API
+    static func getSecondHomeData() -> Observable<HomeSecondData> {
+        return networking(
+            urlStr: HomeAddress.getsecondHomeData.url,
+            method: .get,
+            data: nil,
+            model: HomeSecondData.self)
     }
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Home/HomeAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Home/HomeAddress.swift
@@ -8,14 +8,18 @@
 import Foundation
 
 enum HomeAddress {
-    case getHomeData
+    case getFirstHomeData
+    case getsecondHomeData
 }
 
 extension HomeAddress {
     var url: String {
         switch self {
-        case .getHomeData:
+        case .getFirstHomeData:
             return "perfume/findtest"
+        
+        case .getsecondHomeData:
+            return "perfume/findtest2"
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Home/Model/HomeData.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Home/Model/HomeData.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-struct HomeData: Codable {
+struct HomeFirstData: Codable {
     let mainImage: String
-    let recommend: [RecommendPerfumeList]
+    let recommend: RecommendPerfumeList
 }
 
 struct RecommendPerfumeList: Codable {
@@ -23,3 +23,15 @@ struct RecommendPerfume: Codable {
     let perfumeName: String
     let imageUrl: String
 }
+
+
+struct HomeSecondData: Codable {
+    let recommend: [RecommendPerfumeList]
+    
+    enum CodingKeys: String, CodingKey {
+        case recommend = "data"
+    }
+    
+}
+
+

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Member: Codable {
     var age: Int
-    var imgUrl: String
+    var memberImageUrl: String
     var memberId: Int
     var nickname: String
     var provider: String

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
@@ -18,6 +18,7 @@ final class HomeViewReactor: Reactor {
         case didTapBrandSearchButton
         case didTapSearchButton
         case didTapBellButton
+        case scrollCollectionView
     }
     
     enum Mutation {
@@ -26,6 +27,7 @@ final class HomeViewReactor: Reactor {
         case setIsPresentSearchVC(Bool)
         case setIsPresentBellVC(Bool)
         case setSections([HomeSection])
+        case setPagination(Bool)
     }
     
     struct State {
@@ -34,6 +36,7 @@ final class HomeViewReactor: Reactor {
         var isPresentBrandSearchVC: Bool = false
         var isPresentSearchVC: Bool = false
         var isPresentBellVC: Bool = false
+        var isPaging: Bool = false
     }
     
     init() {
@@ -44,7 +47,7 @@ final class HomeViewReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewDidLoad:
-            return HomeViewReactor.reqeustHomeData()
+            return HomeViewReactor.reqeustHomeFirstData()
         case .itemSelected(let indexPath):
             return .concat([
                 Observable<Mutation>.just(.setSelectedPerfumeId(indexPath)),
@@ -66,6 +69,12 @@ final class HomeViewReactor: Reactor {
             return .concat([
                 .just(.setIsPresentBellVC(true)),
                 .just(.setIsPresentBellVC(false))
+            ])
+            
+        case .scrollCollectionView:
+            return .concat([
+                HomeViewReactor.requstHomeSecondData(),
+                .just(.setPagination(true))
             ])
         }
     }
@@ -95,7 +104,10 @@ final class HomeViewReactor: Reactor {
             state.isPresentBellVC = isPresent
         
         case .setSections(let sections):
-            state.sections = sections
+            state.sections += sections
+            
+        case .setPagination(let isPaging):
+            state.isPaging = isPaging
         }
         return state
 
@@ -104,7 +116,7 @@ final class HomeViewReactor: Reactor {
 
 extension HomeViewReactor {
     
-    static func reqeustHomeData() -> Observable<Mutation> {
+    static func reqeustHomeFirstData() -> Observable<Mutation> {
 
         return HomeAPI.getFirstHomeData()
             .catch { _ in .empty() }
@@ -124,6 +136,24 @@ extension HomeViewReactor {
 
                 return .just(.setSections(sections))
             }
+    }
+    
+    static func requstHomeSecondData() -> Observable<Mutation> {
         
+        return HomeAPI.getSecondHomeData()
+            .catch { _ in .empty() }
+            .flatMap { data -> Observable<Mutation> in
+               
+                var sections = [HomeSection]()
+                
+                data.recommend.forEach {
+                    
+                    let item = $0.perfumeList.map { HomeSectionItem.recommendCell(HomeCellReactor(perfume: $0), $0.id) }
+                    
+                    sections.append(HomeSection.recommendSection(header: $0.title, items: item))
+                }
+                
+                return .just(.setSections(sections))
+            }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
@@ -106,25 +106,22 @@ extension HomeViewReactor {
     
     static func reqeustHomeData() -> Observable<Mutation> {
 
-        return HomeAPI.getHomeData()
+        return HomeAPI.getFirstHomeData()
             .catch { _ in .empty() }
             .flatMap { data -> Observable<Mutation> in
                 var sections = [HomeSection]()
                 
                 let homeTopItem = HomeSectionItem.topCell(data.mainImage, 1)
                 let homeTopSection = HomeSection.topSection([homeTopItem])
-                
+                let recommend = data.recommend
+
                 sections.append(homeTopSection)
-                
-                
-                data.recommend.forEach {
+        
+                let item = recommend.perfumeList.map { HomeSectionItem.recommendCell(HomeCellReactor(perfume: $0), $0.id)}
                     
-                    let item = $0.perfumeList.map { HomeSectionItem.recommendCell(HomeCellReactor(perfume: $0), $0.id)}
-                    
-                    sections.append(HomeSection.recommendSection(header: $0.title, items: item))
-                }
-                
-                
+                sections.append(HomeSection.recommendSection(header: recommend.title, items: item))
+        
+
                 return .just(.setSections(sections))
             }
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
@@ -252,4 +252,3 @@ extension HomeViewController: UICollectionViewDelegate {
         }
     }
 }
-

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
@@ -226,6 +226,9 @@ extension HomeViewController {
     func configureUI() {
         view.backgroundColor = UIColor.white
         
+        homeView.collectionView.rx.setDelegate(self)
+            .disposed(by: disposeBag)
+        
         [homeView] .forEach { view.addSubview($0) }
 
         homeView.snp.makeConstraints {
@@ -235,3 +238,18 @@ extension HomeViewController {
         }
     }
 }
+
+// MARK: - UICollectionViewDelegate
+
+extension HomeViewController: UICollectionViewDelegate {
+    
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+                
+        if indexPath.section == 1 && indexPath.row == 1 {
+            if !homeReactor.currentState.isPaging {
+                homeReactor.action.onNext(.scrollCollectionView)
+            }
+        }
+    }
+}
+

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
@@ -30,7 +30,7 @@ class MyPageReactor: Reactor {
         var sections: [MyPageSection] = []
         var member = Member(
             age: 0,
-            imgUrl: "",
+            memberImageUrl: "",
             memberId: 0,
             nickname: "",
             provider: "",

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/Reactor/MyPageReactor.swift
@@ -138,13 +138,9 @@ extension MyPageReactor {
 
                 var sections = [MyPageSection]()
                 
-                let member = Member(
-                    age: member.age,
-                    imgUrl: member.imgUrl,
-                    memberId: member.memberId,
-                    nickname: member.nickname,
-                    provider: MyPageReactor.providerToKorean(member.provider),
-                    sex: member.sex)
+                guard var member = member else { return .empty() }
+
+                member.provider.changeProvider()
                 
                 sections.append(MyPageSection.memberSection(
                     MyPageSectionItem.memberCell(MemberCellReactor(member: member))))
@@ -156,19 +152,6 @@ extension MyPageReactor {
                     .just(.setSections(sections))
                 ])
             }
-    }
-    
-    static func providerToKorean(_ type: String) -> String {
-        switch type {
-        case "GOOGLE":
-            return "구글 로그인"
-        case "KAKAO":
-            return "카카오 로그인"
-        case "APPLE":
-            return "애플 로그인"
-        default:
-            return ""
-        }
     }
     
     func reactorForMyProfile() -> MyProfileReactor {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/View/MyPageUserCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/View/MyPageUserCell.swift
@@ -61,7 +61,7 @@ extension MyPageUserCell {
             .disposed(by: disposeBag)
         
         reactor.state
-            .map { $0.member.imgUrl }
+            .map { $0.member.memberImageUrl }
             .map { URL(string: $0) }
             .distinctUntilChanged()
             .bind(onNext: { [weak self] in


### PR DESCRIPTION
https://github.com/HMOAA/HMOA_iOS/assets/48830320/af296714-759e-45b2-9c7e-ec88a3de42f6

### 이슈번호
#83 

### 구현 / 추가사항
- 기존 홈 화면 데이터 받아오는 API를 2개로 나눈 API을 통해 페이징을 적용하였습니다.
- 일단 초기에 첫번째 API을 호출하고 UICollectionViewDelegate의 willDisplay 메소드를 이용해서 첫 번째 섹션의 마지막 셀이 보여지게 되면 두번째 API을 호출해 section에 더해주는 방식으로 구현했습니다.
- 추가적으로 Extension을 이용해 String에서 서버로 부터 넘어오는 로그인타입을 형식에 맞게 바꿔주는 함수도 구현했습니다.