### PR TITLE
[Feat] 향수 검색 페이지 기능 구현

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -176,6 +176,9 @@
 		CAD18E1B29C2FFCF005BC997 /* LikeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD18E1A29C2FFCF005BC997 /* LikeCardCell.swift */; };
 		CAD18E1D29C2FFF6005BC997 /* LikeListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD18E1C29C2FFF6005BC997 /* LikeListCell.swift */; };
 		CAE5F2A029F1109800BAF313 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE5F29F29F1109800BAF313 /* Response.swift */; };
+		CAF19B9C2A625D1300374038 /* SearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF19B9B2A625D1300374038 /* SearchAPI.swift */; };
+		CAF19B9E2A625D2100374038 /* SearchAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF19B9D2A625D2100374038 /* SearchAddress.swift */; };
+		CAF19BA32A625F7600374038 /* SearchPerfume.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF19BA22A625F7600374038 /* SearchPerfume.swift */; };
 		CAFA450829AB7DC300ACF2C1 /* YearModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFA450729AB7DC300ACF2C1 /* YearModel.swift */; };
 		CAFA450A29AB7DEA00ACF2C1 /* ChoiceYearViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFA450929AB7DEA00ACF2C1 /* ChoiceYearViewController.swift */; };
 		CAFA451129AB7E4000ACF2C1 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFA451029AB7E4000ACF2C1 /* PaddingLabel.swift */; };
@@ -378,6 +381,9 @@
 		CAD18E1A29C2FFCF005BC997 /* LikeCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeCardCell.swift; sourceTree = "<group>"; };
 		CAD18E1C29C2FFF6005BC997 /* LikeListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeListCell.swift; sourceTree = "<group>"; };
 		CAE5F29F29F1109800BAF313 /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		CAF19B9B2A625D1300374038 /* SearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAPI.swift; sourceTree = "<group>"; };
+		CAF19B9D2A625D2100374038 /* SearchAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAddress.swift; sourceTree = "<group>"; };
+		CAF19BA22A625F7600374038 /* SearchPerfume.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPerfume.swift; sourceTree = "<group>"; };
 		CAFA450729AB7DC300ACF2C1 /* YearModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YearModel.swift; sourceTree = "<group>"; };
 		CAFA450929AB7DEA00ACF2C1 /* ChoiceYearViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceYearViewController.swift; sourceTree = "<group>"; };
 		CAFA451029AB7E4000ACF2C1 /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
@@ -1106,6 +1112,7 @@
 		2CA1559F2A0391C100D7B0C0 /* API */ = {
 			isa = PBXGroup;
 			children = (
+				CAF19B9A2A625CEF00374038 /* Search */,
 				2C8318C52A0FC6BD004A3ACD /* Home */,
 				2CA155AA2A039A1E00D7B0C0 /* Login */,
 				2CA155A22A0391D800D7B0C0 /* Member */,
@@ -1468,6 +1475,24 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		CAF19B9A2A625CEF00374038 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				CAF19B9F2A625E6D00374038 /* Model */,
+				CAF19B9B2A625D1300374038 /* SearchAPI.swift */,
+				CAF19B9D2A625D2100374038 /* SearchAddress.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		CAF19B9F2A625E6D00374038 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				CAF19BA22A625F7600374038 /* SearchPerfume.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		CAFA450629AB7D9B00ACF2C1 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -1753,6 +1778,7 @@
 				2CC12C7D2A2CCC09003B3A60 /* String++Extension.swift in Sources */,
 				CA5DB81929EAA6F500BE0F79 /* LoginModel.swift in Sources */,
 				2C4041CE29ACD94D009247E7 /* SearchBarContainerView.swift in Sources */,
+				CAF19B9E2A625D2100374038 /* SearchAddress.swift in Sources */,
 				CA34781B29E2DAE300334070 /* HPediaGuideHeaderCell.swift in Sources */,
 				2C04249229A504D3009CF0FE /* CommentDetailViewController.swift in Sources */,
 				2C464E5C29CDDCB600A07658 /* MyProfileViewController.swift in Sources */,
@@ -1768,6 +1794,7 @@
 				CA1067D729D6C83C009A7245 /* ChangeYearViewConroller.swift in Sources */,
 				CA6D99E629C492B4000E80CF /* LikeListModel.swift in Sources */,
 				2CA155A42A03921000D7B0C0 /* MemberAPI.swift in Sources */,
+				CAF19B9C2A625D1300374038 /* SearchAPI.swift in Sources */,
 				2C1BD6C42997A6F80059A43D /* CommentFooterView.swift in Sources */,
 				CA051CB0297FDA0F001865F5 /* UserInformationViewController.swift in Sources */,
 				CA91448F297E760800762BC0 /* UITextField++Extenstions.swift in Sources */,
@@ -1856,6 +1883,7 @@
 				CA6D99E829C4932A000E80CF /* ListSecton.swift in Sources */,
 				CA360F3829DD658600A93873 /* HPediaTagData.swift in Sources */,
 				2C8318CE2A0FC779004A3ACD /* HomeAddress.swift in Sources */,
+				CAF19BA32A625F7600374038 /* SearchPerfume.swift in Sources */,
 				2C04247729A3FCED009CF0FE /* PerfumeInfoViewReactor.swift in Sources */,
 				2CD023552A07B5A500459801 /* ChangeNicknameViewController.swift in Sources */,
 				CA03C23E29EBED6C00FA0D2C /* LoginManager.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Search/Model/SearchPerfume.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Search/Model/SearchPerfume.swift
@@ -1,0 +1,28 @@
+//
+//  PerfumeSearch.swift
+//  HMOA_iOS
+//
+//  Created by 정지훈 on 2023/07/15.
+//
+
+import Foundation
+
+struct SearchPerfumeName: Codable {
+    let perfumeName: String
+}
+
+struct SearchPerfume: Codable, Equatable {
+    let brandName: String
+    let isHeart: Bool
+    let perfumeId: Int
+    let perfumeImageUrl: String
+    let perfumeName: String
+    
+    enum CodingKeys: String, CodingKey {
+        case brandName
+        case isHeart = "heart"
+        case perfumeId
+        case perfumeImageUrl
+        case perfumeName
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Search/SearchAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Search/SearchAPI.swift
@@ -1,0 +1,30 @@
+//
+//  SearchAPI.swift
+//  HMOA_iOS
+//
+//  Created by 정지훈 on 2023/07/15.
+//
+
+import Foundation
+import RxSwift
+
+final class SearchAPI {
+    static func getPerfumeName(params: [String: Any]) -> Observable<[SearchPerfumeName]> {
+        return networking(
+            urlStr: SearchAddress.getPerfumeName.url,
+            method: .get,
+            data: nil,
+            model: [SearchPerfumeName].self,
+            query: params
+        )
+    }
+    static func getPerfumeInfo(params: [String: Any]) -> Observable<[SearchPerfume]> {
+        return networking(
+            urlStr: SearchAddress.getPerfumeInfo.url,
+            method: .get,
+            data: nil,
+            model: [SearchPerfume].self,
+            query: params
+        )
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Search/SearchAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Search/SearchAddress.swift
@@ -1,0 +1,24 @@
+//
+//  SearchAddress.swift
+//  HMOA_iOS
+//
+//  Created by 정지훈 on 2023/07/15.
+//
+
+import Foundation
+
+enum SearchAddress {
+    case getPerfumeName
+    case getPerfumeInfo
+}
+
+extension SearchAddress {
+    var url: String {
+        switch self {
+        case .getPerfumeName:
+            return "search/perfumeName"
+        case .getPerfumeInfo:
+            return "search/perfume"
+        }
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/VIewController/SearchViewController.swift
@@ -24,7 +24,7 @@ class SearchViewController: UIViewController, View {
     private lazy var listVC = SearchListViewController()
     private lazy var ResultVC = SearchResultViewController()
     private lazy var containerView = UIView()
-    
+    private var previousSection: Int = -1
     lazy var backButton = UIButton().makeImageButton(UIImage(named: "backButton")!)
     
     lazy var searchBar = UISearchBar().then {
@@ -235,6 +235,8 @@ extension SearchViewController {
         
         view.backgroundColor = .white
         
+        
+        
         listVC.tableView.rx.setDelegate(self)
             .disposed(by: disposeBag)
         
@@ -296,11 +298,20 @@ extension SearchViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 34
     }
+    
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if indexPath.item == tableView.numberOfRows(inSection: tableView.numberOfSections - 1) - 1 {
+            reactor?.action.onNext(.scrollTableView(indexPath))
+            print(indexPath.item + 1)
+        }
+    }
+    
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout
 
-extension SearchViewController: UICollectionViewDelegateFlowLayout {
+extension SearchViewController: UICollectionViewDelegateFlowLayout, UICollectionViewDelegate {
+    
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
@@ -312,4 +323,12 @@ extension SearchViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         return UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
     }
+    
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        
+        if indexPath.item == collectionView.numberOfItems(inSection: collectionView.numberOfSections - 1) - 1 {
+            reactor?.action.onNext(.scrollCollectionView(indexPath))
+        }
+    }
+    
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchResultCollectionViewCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Search/View/SearchResultCollectionViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Kingfisher
 
 class SearchResultCollectionViewCell: UICollectionViewCell {
     
@@ -15,9 +16,7 @@ class SearchResultCollectionViewCell: UICollectionViewCell {
     
     // MARK: - UI Component
     
-    lazy var productImageView = UIImageView().then {
-        $0.backgroundColor = .customColor(.gray3)
-    }
+    lazy var productImageView = UIImageView()
     
     var titleLabel = UILabel().then {
         $0.font = .customFont(.pretendard_medium, 14)
@@ -74,9 +73,9 @@ extension SearchResultCollectionViewCell {
         }
     }
     
-    func updateCell(_ product: Perfume) {
-//        self.productImageView.image = product.image
-        self.titleLabel.text = product.titleName
-        self.contentLabel.text = product.content
+    func updateCell(_ product: SearchPerfume) {
+        self.productImageView.kf.setImage(with: URL(string: product.perfumeImageUrl))
+        self.titleLabel.text = product.perfumeName
+        self.contentLabel.text = product.brandName
     }
 }


### PR DESCRIPTION
![Simulator Screen Recording - iPhone 14 - 2023-07-21 at 12 41 33](https://github.com/HMOAA/HMOA_iOS/assets/75370733/541f2c7c-e535-4507-891e-84c7c1e51680)

### 이슈 번호
#91 

### 추가/구현 사항
- 현재 향수 이름 리스트가 10개로 오는데 화면에 반 정도를 차지해 개수가 늘어나면 수정하겠습니다.
- 테이블뷰, 콜렉션뷰 모두 섹션이 하나라 마지막 아이템이 감지 될 때 다음 페이지에 값들을 받아오게 구현 했습니다.