### PR TITLE
[UI] 매거진 UI 관련 업데이트

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HMOA_iOS/HMOA_iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "17ad9c1b9344646ba7987bf9895fd5665d055e04b39c551c26234393538683d7",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+        "version" : "5.9.1"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk.git",
+      "state" : {
+        "revision" : "ab226a7a3625d64e73a52aa3800595dab810156b",
+        "version" : "2.22.1"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk-rx",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk-rx",
+      "state" : {
+        "revision" : "f7c88fc197529464302a75ee351d105975d18bf6",
+        "version" : "2.22.1"
+      }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "pretendardkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/wookeon/PretendardKit.git",
+      "state" : {
+        "revision" : "d8362d8ecee86c297f2784fa453037136914bc2c",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "rxalamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxAlamofire.git",
+      "state" : {
+        "revision" : "9535b58695b91fb67f56d58d6fd0c76462d7743a",
+        "version" : "6.1.2"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
+        "version" : "6.7.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -11,6 +11,12 @@ import Then
 
 extension UIViewController {
     
+    /// Height of status bar + navigation bar (if navigation bar exist)
+    var topbarHeight: CGFloat {
+        return (view.window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0.0) +
+        (self.navigationController?.navigationBar.frame.height ?? 0.0)
+    }
+    
     // MARK: - Push or Present VC
     
     /// 튜토리얼 페이지 전환 여부

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Magazine/Magazine/Viewcontroller/MagazineViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Magazine/Magazine/Viewcontroller/MagazineViewController.swift
@@ -399,9 +399,14 @@ extension MagazineViewController {
         ]
         
         self.navigationController?.navigationBar.scrollEdgeAppearance = scrollEdgeAppearance
-        self.navigationController?.navigationBar.standardAppearance.titleTextAttributes = [
+        
+        let standardAppearance = UINavigationBarAppearance()
+        standardAppearance.backgroundColor = .clear
+        standardAppearance.titleTextAttributes = [
             NSAttributedString.Key.font: UIFont.customFont(.pretendard, 20)
         ]
+        
+        self.navigationController?.navigationBar.standardAppearance = standardAppearance
     }
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Magazine/Magazine/Viewcontroller/MagazineViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Magazine/Magazine/Viewcontroller/MagazineViewController.swift
@@ -220,7 +220,7 @@ class MagazineViewController: UIViewController, View {
                 let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
                 
                 let section = NSCollectionLayoutSection(group: group)
-                section.contentInsets = NSDirectionalEdgeInsets(top: 115, leading: 0, bottom: 22, trailing: 0)
+                section.contentInsets = NSDirectionalEdgeInsets(top: self.topbarHeight + 8, leading: 0, bottom: 22, trailing: 0)
                 section.orthogonalScrollingBehavior = .groupPagingCentered
                 section.interGroupSpacing = 4
                 section.decorationItems = [backgroundDecoration]


### PR DESCRIPTION
# 📌 이슈번호
- #166

# 📌 구현/추가 사항
- 상태바 + 네비게이션바의 높이를 저장하는 연산 프로퍼티를 추가해 매거진 배너 섹션에 적용했습니다.
- 네비게이션바의 standardAppearance를 설정해주어 출시향수에서 DetailVC로 push 후 돌아왔을 때 네비게이션바도 원래대로 돌아올 수 있도록 수정했습니다.

# 📷 미리보기
- 구현한 내용을 보여주세요.
