### PR TITLE
[UI] 추가 카테고리 선택까지 UI 구현

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/Home/HBTI/Contents.json
+++ b/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/Home/HBTI/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/Home/HBTI/Notes/Contents.json
+++ b/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/Home/HBTI/Notes/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/Reactor/HBTINotesCategoryReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/Reactor/HBTINotesCategoryReactor.swift
@@ -1,0 +1,8 @@
+//
+//  HBTINotesCategoryReactor.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 7/30/24.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/Reactor/HBTINotesResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/Reactor/HBTINotesResultReactor.swift
@@ -1,0 +1,8 @@
+//
+//  HBTINotesResultReactor.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 8/6/24.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/Reactor/HBTIProcessGuideReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/Reactor/HBTIProcessGuideReactor.swift
@@ -1,0 +1,45 @@
+//
+//  HBTIDetailReactor.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 7/29/24.
+//
+
+import RxSwift
+import ReactorKit
+
+class HBTIProcessGuideReactor: Reactor {
+    enum Action {
+        case nextButtonTapped
+    }
+    
+    enum Mutation {
+        case setShowQuantitySelection(Bool)
+    }
+    
+    struct State {
+        var showQuantitySelection: Bool = false
+    }
+    
+    var initialState: State
+    
+    init() {
+        self.initialState = State()
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .nextButtonTapped:
+            return .just(.setShowQuantitySelection(true))
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .setShowQuantitySelection(let show):
+            newState.showQuantitySelection = show
+        }
+        return newState
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/Reactor/HBTIQuantitySelectionReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/Reactor/HBTIQuantitySelectionReactor.swift
@@ -1,0 +1,8 @@
+//
+//  HBTIQuantitySelectionReactor.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 7/30/24.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/View/HBTINotesCategoryView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/View/HBTINotesCategoryView.swift
@@ -1,0 +1,8 @@
+//
+//  HBTINotesCategoryView.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 7/30/24.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/View/HBTINotesResultView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/View/HBTINotesResultView.swift
@@ -1,0 +1,8 @@
+//
+//  HBTINotesResultView.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 8/6/24.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/View/HBTIProcessGuideView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/View/HBTIProcessGuideView.swift
@@ -1,0 +1,154 @@
+//
+//  HBTIProcessInnerView.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 7/30/24.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxSwift
+import RxCocoa
+
+class HBTIProcessGuideView: UIView {
+    let nextButtonTapped = PublishRelay<Void>()
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - UI Components
+    
+    private let processFullStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 34
+        $0.distribution = .equalSpacing
+    }
+    
+    private var processPartStackViews: [UIStackView] = []
+    private let nextButton = UIButton()
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setAddView()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Set UI
+    
+    private func setUI() {
+        let items = [
+            ("향료 선택", "향BTI 검사 이후 추천하는 향료, 원하는 향료 선택\n(기격대 상이)"),
+            ("배송", "결제 후 1-2일 내 배송 완료"),
+            ("향수 추천", "시향 후 가장 좋았던 향료 선택, 향수 추천 받기")
+        ]
+        
+        for (index, item) in items.enumerated() {
+            let partStackView = createItemView(number: index + 1, title: item.0, description: item.1)
+            processPartStackViews.append(partStackView)
+        }
+        
+        makeHBTIButton(
+            nextButton,
+            withTitle: "다음",
+            withState: .normal
+        )
+        
+        bindButton()
+    }
+    
+    // MARK: - Set AddView
+    
+    private func setAddView() {
+        [processFullStackView,
+         nextButton
+        ].forEach { self.addSubview($0) }
+        
+        processPartStackViews.forEach {
+            processFullStackView.addArrangedSubview($0)
+        }
+    }
+    
+    // MARK: - Set Constraints
+    
+    private func setConstraints() {
+        processFullStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(127)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().offset(-16)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().offset(628)
+            $0.width.equalTo(328)
+            $0.height.equalTo(52)
+        }
+    }
+    
+    // MARK: - Make PartStackView
+    
+    private func createItemView(number: Int, title: String, description: String) -> UIStackView {
+        let processPartStackView = UIStackView().then {
+            $0.axis = .horizontal
+            $0.spacing = 10
+            $0.alignment = .top
+        }
+        
+        let processLeftStackView = UIStackView().then {
+            $0.axis = .vertical
+        }
+        
+        let processRightStackView = UIStackView().then {
+            $0.axis = .vertical
+            $0.spacing = 5
+        }
+        
+        let numberLabel = UILabel().then {
+            $0.setLabelUI("\(number)", font: .pretendard, size: 12, color: .black)
+            $0.textAlignment = .center
+            $0.backgroundColor = UIColor.customColor(.searchBarColor)
+            $0.layer.cornerRadius = 10
+            $0.clipsToBounds = true
+        }
+        
+        let titleLabel = UILabel().then {
+            $0.setLabelUI(title, font: .pretendard_bold, size: 16, color: .black)
+        }
+        
+        let descriptionLabel = UILabel().then {
+            $0.setLabelUI(description, font: .pretendard, size: 12, color: .gray5)
+            $0.numberOfLines = 0
+        }
+        
+        processLeftStackView.addArrangedSubview(numberLabel)
+        [titleLabel, descriptionLabel].forEach { processRightStackView.addArrangedSubview($0) }
+        
+        [processLeftStackView, processRightStackView].forEach { processPartStackView.addArrangedSubview($0) }
+        
+        numberLabel.snp.makeConstraints { make in
+            make.width.height.equalTo(20)
+        }
+        
+        return processPartStackView
+    }
+    
+    private func bindButton() {
+        nextButton.rx.tap
+            .bind(to: nextButtonTapped)
+            .disposed(by: disposeBag)
+    }
+    
+    func makeHBTIButton(_ button: UIButton, withTitle title: String, withState state: UIControl.State) {
+        button.setTitle(title, for: state)
+        button.setTitleColor(.white, for: state)
+        button.backgroundColor = .black
+        button.layer.cornerRadius = 5
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/View/HBTIQuantitySelctionView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/View/HBTIQuantitySelctionView.swift
@@ -1,0 +1,8 @@
+//
+//  HBTIQuantitySelctionView.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 7/29/24.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/ViewController/HBTINotesCategoryViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/ViewController/HBTINotesCategoryViewController.swift
@@ -1,0 +1,8 @@
+//
+//  HBTINotesCategoryViewController.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 7/30/24.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/ViewController/HBTINotesResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/ViewController/HBTINotesResultViewController.swift
@@ -1,0 +1,8 @@
+//
+//  HBTINotesResultViewController.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 8/6/24.
+//
+
+import Foundation

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/ViewController/HBTIProcessGuideViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/ViewController/HBTIProcessGuideViewController.swift
@@ -1,0 +1,61 @@
+//
+//  HBTIDetailViewController.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 7/29/24.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxSwift
+import ReactorKit
+
+class HBTIProcessGuideViewController: UIViewController, View {
+    var disposeBag = DisposeBag()
+    
+    private let hbtiProcessInnerView = HBTIProcessGuideView()
+    private let hbtiSelectionView = HBTIQuantitySelctionView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+        setupView()
+        setupConstraints()
+    }
+    
+    private func setUI() {
+        setClearBackNaviBar("향BTI", .black)
+    }
+    
+    private func setupView() {
+        [hbtiProcessInnerView
+         ].forEach {
+            view.addSubview($0)
+        }
+
+    }
+    
+    private func setupConstraints() {
+        hbtiProcessInnerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    func bind(reactor: HBTIDetailReactor) {
+        hbtiProcessInnerView.nextButtonTapped
+            .subscribe(onNext: { [weak self] in
+                self?.showQuantitySelectionView()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func showQuantitySelectionView() {
+        let quantitySelectionView = HBTIQuantitySelctionView()
+        let quantitySelectionVC = UIViewController()
+        quantitySelectionVC.view = quantitySelectionView
+        navigationController?.pushViewController(quantitySelectionVC, animated: true)
+    }
+
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/ViewController/HBTIQuantitySelectionViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIDetail/ViewController/HBTIQuantitySelectionViewController.swift
@@ -1,0 +1,8 @@
+//
+//  HBTIQuantitySelectionViewController.swift
+//  HMOA_iOS
+//
+//  Created by HyoTaek on 7/30/24.
+//
+
+import Foundation


### PR DESCRIPTION
# 📌 이슈번호
- #184 

# 📌 구현/추가 사항
- 테스트로 페이지 넘어가기 위해 임시로 HBTI 폴더의 reactor, view, viewController를 수정해습니다.
- 네비게이션 애니메이션 및 뒤로가기는 추후 수정하도록 하겠습니다.
- 향료 개수 선택했을 때의 UI도 추후 구현하겠습니다.
- 추가 카테고리 이미지는 svg 에러로 추후 업데이트 하겠습니다.
- 추가 카테고리 선택시 이미지 투명도, 외부 원 UI도 추후 업이드 하겠습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/577d3fcd-88f2-48d8-93fa-2e8a1afb40b6
