### PR TITLE
[UI] 향BTI 설문결과화면 컴포넌트

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		C9D161E52C1FF2550032FE78 /* IgnoerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D161E42C1FF2550032FE78 /* IgnoerData.swift */; };
 		C9D230072C69F583008ACB9B /* loading.gif in Resources */ = {isa = PBXBuildFile; fileRef = C9D230062C69F583008ACB9B /* loading.gif */; };
 		C9D2300B2C69F601008ACB9B /* HBTILoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */; };
+		C9D2300D2C6AE106008ACB9B /* HBTISurveyResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */; };
 		CA0027C52B2C5E7D001DEAE3 /* TutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */; };
 		CA0027C72B2C60F8001DEAE3 /* TutorialContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */; };
 		CA0160962AB0B11100D5839D /* SecondDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0160952AB0B11100D5839D /* SecondDetail.swift */; };
@@ -469,6 +470,7 @@
 		C9D161E42C1FF2550032FE78 /* IgnoerData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IgnoerData.swift; path = ../../../../../../../../../Downloads/IgnoerData.swift; sourceTree = "<group>"; };
 		C9D230062C69F583008ACB9B /* loading.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; name = loading.gif; path = ../../../../../../.Trash/loading.gif; sourceTree = "<group>"; };
 		C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTILoadingView.swift; sourceTree = "<group>"; };
+		C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTISurveyResultCell.swift; sourceTree = "<group>"; };
 		CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialViewController.swift; sourceTree = "<group>"; };
 		CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialContentViewController.swift; sourceTree = "<group>"; };
 		CA0160952AB0B11100D5839D /* SecondDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondDetail.swift; sourceTree = "<group>"; };
@@ -1518,6 +1520,7 @@
             isa = PBXGroup;
             children = (
                 C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */,
+                C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */,
             );
             path = View;
             sourceTree = "<group>";
@@ -2974,6 +2977,7 @@
 				2C39AA7B29705524000C6F71 /* UIColor++Extenstions.swift in Sources */,
 				CA0027C52B2C5E7D001DEAE3 /* TutorialViewController.swift in Sources */,
 				2C4041D429ACDC67009247E7 /* SearchResultViewController.swift in Sources */,
+				C9D2300D2C6AE106008ACB9B /* HBTISurveyResultCell.swift in Sources */,
 				2CD023512A07AEBC00459801 /* NicknameView.swift in Sources */,
 				2C4CDC4929C770D900676163 /* BrandListHeaderView.swift in Sources */,
 				2C8318C72A0FC6D0004A3ACD /* HomeAPI.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		C9D230072C69F583008ACB9B /* loading.gif in Resources */ = {isa = PBXBuildFile; fileRef = C9D230062C69F583008ACB9B /* loading.gif */; };
 		C9D2300B2C69F601008ACB9B /* HBTILoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */; };
 		C9D2300D2C6AE106008ACB9B /* HBTISurveyResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */; };
+		C9D2300F2C6AE63C008ACB9B /* HBTISurveyResultSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300E2C6AE63C008ACB9B /* HBTISurveyResultSection.swift */; };
 		CA0027C52B2C5E7D001DEAE3 /* TutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */; };
 		CA0027C72B2C60F8001DEAE3 /* TutorialContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */; };
 		CA0160962AB0B11100D5839D /* SecondDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0160952AB0B11100D5839D /* SecondDetail.swift */; };
@@ -471,6 +472,7 @@
 		C9D230062C69F583008ACB9B /* loading.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; name = loading.gif; path = ../../../../../../.Trash/loading.gif; sourceTree = "<group>"; };
 		C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTILoadingView.swift; sourceTree = "<group>"; };
 		C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTISurveyResultCell.swift; sourceTree = "<group>"; };
+		C9D2300E2C6AE63C008ACB9B /* HBTISurveyResultSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTISurveyResultSection.swift; sourceTree = "<group>"; };
 		CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialViewController.swift; sourceTree = "<group>"; };
 		CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialContentViewController.swift; sourceTree = "<group>"; };
 		CA0160952AB0B11100D5839D /* SecondDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondDetail.swift; sourceTree = "<group>"; };
@@ -1504,6 +1506,7 @@
         C93CA2092C69E6A900AFD9E8 /* Model */ = {
             isa = PBXGroup;
             children = (
+                C9D2300E2C6AE63C008ACB9B /* HBTISurveyResultSection.swift */,
             );
             path = Model;
             sourceTree = "<group>";
@@ -2877,6 +2880,7 @@
 				2C39AA682970481F000C6F71 /* HomeViewController.swift in Sources */,
 				C96CD73E2BA88010005C9856 /* MagazineNewPerfumeCell.swift in Sources */,
 				2C04249B29A656BB009CF0FE /* CommentWriteViewController.swift in Sources */,
+				C9D2300F2C6AE63C008ACB9B /* HBTISurveyResultSection.swift in Sources */,
 				CA99A6CE2B1201B10030364F /* MyLogWritedPostReactor.swift in Sources */,
 				2C1BD6B3298FF14F0059A43D /* SimilarHeaderView.swift in Sources */,
 				CA6C48632B2C2FFF00F1BE7F /* TotalPerfumeAPI.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -120,6 +120,8 @@
 		C93BFA6D2C428E9300A5D9D2 /* IntroViewHBTI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA6C2C428E9300A5D9D2 /* IntroViewHBTI.swift */; };
 		C93BFA762C4295FC00A5D9D2 /* HBTISurveyReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA6F2C4295FC00A5D9D2 /* HBTISurveyReactor.swift */; };
 		C93BFA782C4295FC00A5D9D2 /* HBTISurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA742C4295FC00A5D9D2 /* HBTISurveyViewController.swift */; };
+		C93CA20F2C69E6D600AFD9E8 /* HBTISurveyResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CA20E2C69E6D600AFD9E8 /* HBTISurveyResultViewController.swift */; };
+		C93CA2112C69EC6E00AFD9E8 /* HBTISurveyResultReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93CA2102C69EC6E00AFD9E8 /* HBTISurveyResultReactor.swift */; };
 		C94EE0AF2C1FFBC9005EDC95 /* PushAlarmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94EE0AE2C1FFBC9005EDC95 /* PushAlarmViewController.swift */; };
 		C94EE0B22C1FFEDD005EDC95 /* PushAlarmReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94EE0B12C1FFEDD005EDC95 /* PushAlarmReactor.swift */; };
 		C96B99D22BB022B6005F4E31 /* MagazineTagCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96B99D12BB022B6005F4E31 /* MagazineTagCell.swift */; };
@@ -424,6 +426,8 @@
 		C93BFA6C2C428E9300A5D9D2 /* IntroViewHBTI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewHBTI.swift; sourceTree = "<group>"; };
 		C93BFA6F2C4295FC00A5D9D2 /* HBTISurveyReactor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HBTISurveyReactor.swift; sourceTree = "<group>"; };
 		C93BFA742C4295FC00A5D9D2 /* HBTISurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HBTISurveyViewController.swift; sourceTree = "<group>"; };
+		C93CA20E2C69E6D600AFD9E8 /* HBTISurveyResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTISurveyResultViewController.swift; sourceTree = "<group>"; };
+		C93CA2102C69EC6E00AFD9E8 /* HBTISurveyResultReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTISurveyResultReactor.swift; sourceTree = "<group>"; };
 		C94EE0AE2C1FFBC9005EDC95 /* PushAlarmViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushAlarmViewController.swift; sourceTree = "<group>"; };
 		C94EE0B12C1FFEDD005EDC95 /* PushAlarmReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushAlarmReactor.swift; sourceTree = "<group>"; };
 		C96B99D12BB022B6005F4E31 /* MagazineTagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineTagCell.swift; sourceTree = "<group>"; };
@@ -1479,6 +1483,47 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
+		C93CA20D2C69E6A900AFD9E8 /* HBTISurveyResult */ = {
+			isa = PBXGroup;
+			children = (
+				C93CA2092C69E6A900AFD9E8 /* Model */,
+				C93CA20A2C69E6A900AFD9E8 /* Reactor */,
+				C93CA20B2C69E6A900AFD9E8 /* View */,
+				C93CA20C2C69E6A900AFD9E8 /* ViewController */,
+			);
+			path = HBTISurveyResult;
+			sourceTree = "<group>";
+		};
+        C93CA2092C69E6A900AFD9E8 /* Model */ = {
+            isa = PBXGroup;
+            children = (
+            );
+            path = Model;
+            sourceTree = "<group>";
+        };
+        C93CA20A2C69E6A900AFD9E8 /* Reactor */ = {
+            isa = PBXGroup;
+            children = (
+                C93CA2102C69EC6E00AFD9E8 /* HBTISurveyResultReactor.swift */,
+            );
+            path = Reactor;
+            sourceTree = "<group>";
+        };
+        C93CA20B2C69E6A900AFD9E8 /* View */ = {
+            isa = PBXGroup;
+            children = (
+            );
+            path = View;
+            sourceTree = "<group>";
+        };
+        C93CA20C2C69E6A900AFD9E8 /* ViewController */ = {
+            isa = PBXGroup;
+            children = (
+                C93CA20E2C69E6D600AFD9E8 /* HBTISurveyResultViewController.swift */,
+            );
+            path = ViewController;
+            sourceTree = "<group>";
+        };
 		C94EE0AA2C1FFB71005EDC95 /* PushAlarm */ = {
 			isa = PBXGroup;
 			children = (
@@ -1649,6 +1694,7 @@
 		C96F76032C3FB34800D44773 /* HBTI */ = {
 			isa = PBXGroup;
 			children = (
+				C93CA20D2C69E6A900AFD9E8 /* HBTISurveyResult */,
 				C96F760D2C40065600D44773 /* HBTI */,
 				C93BFA6E2C4295C200A5D9D2 /* HBTISurvey */,
 			);
@@ -2709,6 +2755,7 @@
 				CAA1160A2AC16ABD0063806C /* BrandAPI.swift in Sources */,
 				C96CD7442BA88010005C9856 /* MagazineListCell.swift in Sources */,
 				CA0027C72B2C60F8001DEAE3 /* TutorialContentViewController.swift in Sources */,
+				C93CA20F2C69E6D600AFD9E8 /* HBTISurveyResultViewController.swift in Sources */,
 				C96CD73C2BA88010005C9856 /* MagazineAllCell.swift in Sources */,
 				CAF19B9E2A625D2100374038 /* SearchAddress.swift in Sources */,
 				CA4744692AC7EC0E00003584 /* CommunityAPI.swift in Sources */,
@@ -2801,6 +2848,7 @@
 				2C724E2F29AB1A120057D9B4 /* CommentListTopView.swift in Sources */,
 				CA5E872F2B2AED13006DD2FA /* PushAlarmAddress.swift in Sources */,
 				CAA5926B2B049197003DAE51 /* ImageListViewController.swift in Sources */,
+				C93CA2112C69EC6E00AFD9E8 /* HBTISurveyResultReactor.swift in Sources */,
 				2C15DF912A57DFE000EAB112 /* CoreGraphicManager.swift in Sources */,
 				2C464E4929CDB16A00A07658 /* MyPageReactor.swift in Sources */,
 				CA2238902AAEFCC000452A31 /* CommunityWriteViewController.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		C99E7B692BA96DE200F359BC /* MagazineDetailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99E7B682BA96DE200F359BC /* MagazineDetailItem.swift */; };
 		C99E7B6B2BA9F0B500F359BC /* MagazineDetailLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99E7B6A2BA9F0B500F359BC /* MagazineDetailLineView.swift */; };
 		C9D161E52C1FF2550032FE78 /* IgnoerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D161E42C1FF2550032FE78 /* IgnoerData.swift */; };
+		C9D230072C69F583008ACB9B /* loading.gif in Resources */ = {isa = PBXBuildFile; fileRef = C9D230062C69F583008ACB9B /* loading.gif */; };
+		C9D2300B2C69F601008ACB9B /* HBTILoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */; };
 		CA0027C52B2C5E7D001DEAE3 /* TutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */; };
 		CA0027C72B2C60F8001DEAE3 /* TutorialContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */; };
 		CA0160962AB0B11100D5839D /* SecondDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0160952AB0B11100D5839D /* SecondDetail.swift */; };
@@ -465,6 +467,8 @@
 		C99E7B682BA96DE200F359BC /* MagazineDetailItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineDetailItem.swift; sourceTree = "<group>"; };
 		C99E7B6A2BA9F0B500F359BC /* MagazineDetailLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineDetailLineView.swift; sourceTree = "<group>"; };
 		C9D161E42C1FF2550032FE78 /* IgnoerData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IgnoerData.swift; path = ../../../../../../../../../Downloads/IgnoerData.swift; sourceTree = "<group>"; };
+		C9D230062C69F583008ACB9B /* loading.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; name = loading.gif; path = ../../../../../../.Trash/loading.gif; sourceTree = "<group>"; };
+		C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTILoadingView.swift; sourceTree = "<group>"; };
 		CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialViewController.swift; sourceTree = "<group>"; };
 		CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialContentViewController.swift; sourceTree = "<group>"; };
 		CA0160952AB0B11100D5839D /* SecondDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondDetail.swift; sourceTree = "<group>"; };
@@ -859,6 +863,7 @@
 				2C39AA7629704C2F000C6F71 /* Info.plist */,
 				2C39AA23296DB4E0000C6F71 /* LaunchScreen.storyboard */,
 				2C39AA21296DB4E0000C6F71 /* Assets.xcassets */,
+				C9D230062C69F583008ACB9B /* loading.gif */,
 				2C39AA1E296DB4DE000C6F71 /* HMOA_iOS.xcdatamodeld */,
 			);
 			path = Resource;
@@ -1512,6 +1517,7 @@
         C93CA20B2C69E6A900AFD9E8 /* View */ = {
             isa = PBXGroup;
             children = (
+                C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */,
             );
             path = View;
             sourceTree = "<group>";
@@ -2581,6 +2587,7 @@
 				CAA4245C2B6BF24D0005975D /* Settings.bundle in Resources */,
 				CAF177092BB58BAF00A8F66E /* GoogleService-Info.plist in Resources */,
 				2C39AA25296DB4E0000C6F71 /* LaunchScreen.storyboard in Resources */,
+				C9D230072C69F583008ACB9B /* loading.gif in Resources */,
 				2C39AA22296DB4E0000C6F71 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2817,6 +2824,7 @@
 				2C04249D29A65C32009CF0FE /* CommentWriteReactor.swift in Sources */,
 				CA22389B2AAF492D00452A31 /* CommunityPostCell.swift in Sources */,
 				CA6C48612B2C2F8C00F1BE7F /* TotalPerfumeAddress.swift in Sources */,
+				C9D2300B2C69F601008ACB9B /* HBTILoadingView.swift in Sources */,
 				CA99A6D12B1216DE0030364F /* ReportAPI.swift in Sources */,
 				C96CD7402BA88010005C9856 /* MagazineViewController.swift in Sources */,
 				CA16AC8629BCD83E00FD57C1 /* ChoiceYearReactor.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/HPedia/addButton.imageset/Contents.json
+++ b/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/HPedia/addButton.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "버튼 (1) 1.svg",
+      "filename" : "버튼 (1) 1.svg",
       "idiom" : "universal",
       "scale" : "1x"
     },

--- a/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/HPedia/addButton.imageset/Contents.json
+++ b/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/HPedia/addButton.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "버튼 (1) 1.svg",
+      "filename" : "버튼 (1) 1.svg",
       "idiom" : "universal",
       "scale" : "1x"
     },

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -283,6 +283,14 @@ extension UIViewController {
         self.navigationController?.pushViewController(hbtiSurveyVC, animated: true)
     }
     
+    /// HBTISurveyResultVC로 push
+    func presentHBTISurveyResultViewController() {
+        let hbtiSurveyResultVC = HBTISurveyResultViewController()
+        hbtiSurveyResultVC.reactor = HBTISurveyResultReactor()
+        hbtiSurveyResultVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(hbtiSurveyResultVC, animated: true)
+    }
+    
     // MARK: Configure NavigationBar
     
     /// 확인 버튼, 취소 버튼 navigation bar

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Model/HBTISurveyResultSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Model/HBTISurveyResultSection.swift
@@ -1,0 +1,45 @@
+//
+//  HBTISurveyResultSection.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 8/13/24.
+//
+
+import Foundation
+
+enum HBTISurveyResultSection: Hashable {
+    case recommand
+}
+
+enum HBTISurveyResultItem: Hashable {
+    case recommand(HBTISurveyResultNote)
+}
+
+extension HBTISurveyResultItem {
+    var question: HBTISurveyResultNote? {
+        if case .recommand(let note) = self {
+            return note
+        } else {
+            return nil
+        }
+    }
+}
+
+// TODO: HBTI 설문 병합 후 이동
+struct HBTISurveyResultResponse: Hashable {
+    let recommandNotes: [HBTISurveyResultNote]
+}
+
+struct HBTISurveyResultNote: Hashable {
+    let id: Int
+    let name: String
+    let photoURL: String
+    let content: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "noteId"
+        case name = "noteName"
+        case photoURL = "notePhotoUrl"
+        case content
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
@@ -1,0 +1,37 @@
+//
+//  HBTISurveyResultReactor.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 8/12/24.
+//
+import ReactorKit
+import RxSwift
+
+class HBTISurveyResultReactor: Reactor {
+    
+    enum Action {
+        
+    }
+    
+    enum Mutation {
+        
+    }
+    
+    struct State {
+        
+    }
+    
+    var initialState: State
+    
+    init() {
+        self.initialState = State()
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTILoadingView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTILoadingView.swift
@@ -1,0 +1,80 @@
+//
+//  HBTILoadingView.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 8/12/24.
+//
+
+import UIKit
+
+import Gifu
+import SnapKit
+import Then
+
+class HBTILoadingView: UIView {
+
+    // MARK: - UI Components
+    
+    private let loadingImage = GIFImageView().then {
+        $0.animate(withGIFNamed: "loading")
+        $0.contentMode = .scaleAspectFit
+        $0.backgroundColor = UIColor.random
+    }
+    
+    private let waitLabel = UILabel().then {
+        $0.setLabelUI("잠시만 기다려주세요...", font: .pretendard, size: 16, color: .black)
+    }
+    
+    private let descriptionLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard_bold, size: 22, color: .black)
+        $0.setTextWithLineHeight(text: "OOO님에게 딱 맞는 \n향료를 추천하는 중입니다.", lineHeight: 28)
+        $0.numberOfLines = 2
+        $0.lineBreakStrategy = .hangulWordPriority
+        $0.textAlignment = .center
+    }
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setAddView()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Set UI
+    
+    private func setAddView() {
+        [
+            loadingImage,
+            waitLabel,
+            descriptionLabel
+        ] .forEach { addSubview($0) }
+    }
+    
+    private func setConstraints() {
+        loadingImage.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.centerX.equalToSuperview()
+            make.height.width.equalTo(110)
+        }
+        
+        waitLabel.snp.makeConstraints { make in
+            make.top.equalTo(loadingImage.snp.bottom).offset(28)
+            make.centerX.equalTo(loadingImage.snp.centerX)
+        }
+        
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(waitLabel.snp.bottom).offset(15)
+            make.centerX.bottom.equalToSuperview()
+        }
+    }
+    
+    func setDescriptionLabelText(with username: String) {
+        descriptionLabel.text = "\(username)님에게 딱 맞는 \n향료를 추천하는 중입니다."
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
@@ -66,7 +66,7 @@ class HBTISurveyResultCell: UICollectionViewCell {
             let imageHeight = (236.0 / 249.0) * availableWidth
             
             make.top.horizontalEdges.equalToSuperview()
-            make.height.equalTo(imageHeight)
+            make.height.equalTo(236)
         }
         
         nameLabel.snp.makeConstraints { make in
@@ -82,7 +82,8 @@ class HBTISurveyResultCell: UICollectionViewCell {
     }
     
     func configureCell(note: HBTISurveyResultNote) {
-        bannerImageView.kf.setImage(with: URL(string: note.photoURL))
+//        bannerImageView.kf.setImage(with: URL(string: note.photoURL))
+        bannerImageView.backgroundColor = .random
         nameLabel.text = note.name
         descriptionLabel.text = note.content
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
@@ -62,9 +62,6 @@ class HBTISurveyResultCell: UICollectionViewCell {
     
     private func setConstraints() {
         bannerImageView.snp.makeConstraints { make in
-            let availableWidth = layer.frame.width
-            let imageHeight = (236.0 / 249.0) * availableWidth
-            
             make.top.horizontalEdges.equalToSuperview()
             make.height.equalTo(236)
         }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import Then
 import SnapKit
 
@@ -78,5 +79,11 @@ class HBTISurveyResultCell: UICollectionViewCell {
             make.horizontalEdges.equalToSuperview().inset(20)
             make.bottom.equalToSuperview().inset(24)
         }
+    }
+    
+    func configureCell(note: HBTISurveyResultNote) {
+        bannerImageView.kf.setImage(with: URL(string: note.photoURL))
+        nameLabel.text = note.name
+        descriptionLabel.text = note.content
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
@@ -1,0 +1,82 @@
+//
+//  HBTISurveyResultCell.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 8/13/24.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+
+class HBTISurveyResultCell: UICollectionViewCell {
+    
+    static let identifier = "HBTISurveyResultCell"
+    
+    // MARK: - UI Components
+    
+    private let bannerImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+    }
+    
+    private let nameLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard_bold, size: 16, color: .white)
+    }
+    
+    private let descriptionLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard_light, size: 12, color: .white)
+        $0.setTextWithLineHeight(text: "설명\n2줄", lineHeight: 15)
+        $0.numberOfLines = 2
+        $0.lineBreakStrategy = .hangulWordPriority
+    }
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setAddView()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Function
+    
+    private func setUI() {
+        backgroundColor = .black
+    }
+    
+    private func setAddView() {
+        [
+            bannerImageView,
+            nameLabel,
+            descriptionLabel
+        ].forEach { addSubview($0) }
+    }
+    
+    private func setConstraints() {
+        bannerImageView.snp.makeConstraints { make in
+            let availableWidth = layer.frame.width
+            let imageHeight = (236.0 / 249.0) * availableWidth
+            
+            make.top.horizontalEdges.equalToSuperview()
+            make.height.equalTo(imageHeight)
+        }
+        
+        nameLabel.snp.makeConstraints { make in
+            make.top.equalTo(bannerImageView.snp.bottom).offset(20)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(nameLabel.snp.bottom).offset(7)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(24)
+        }
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -46,6 +46,8 @@ class HBTISurveyResultViewController: UIViewController, View {
     
     var disposeBag = DisposeBag()
     
+    private var dataSource: UICollectionViewDiffableDataSource<HBTISurveyResultSection, HBTISurveyResultItem>?
+    
     // MARK: - LifeCycle
 
     override func viewDidLoad() {
@@ -54,6 +56,7 @@ class HBTISurveyResultViewController: UIViewController, View {
         setUI()
         setAddView()
         setConstraints()
+        configureDataSource()
     }
     
     // MARK: - Bind
@@ -82,7 +85,8 @@ class HBTISurveyResultViewController: UIViewController, View {
         // 결과 화면
         [
             bestLabel,
-            secondThirdLabel
+            secondThirdLabel,
+            hbtiSurveyResultCollectionView
         ] .forEach { view.addSubview($0) }
     }
     
@@ -101,6 +105,12 @@ class HBTISurveyResultViewController: UIViewController, View {
             make.top.equalTo(bestLabel.snp.bottom).offset(12)
             make.leading.equalToSuperview().inset(16)
         }
+        
+        hbtiSurveyResultCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(secondThirdLabel.snp.bottom).offset(29)
+            make.horizontalEdges.equalToSuperview()
+            make.height.lessThanOrEqualTo(400)
+        }
     }
     
     // MARK: Create Layout
@@ -109,26 +119,53 @@ class HBTISurveyResultViewController: UIViewController, View {
             (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
             
             let bannerWidthRatio = 249.0 / 360.0
-            let bannerHeight = 333.0 / 249.0 * bannerWidthRatio
             
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1),
-                heightDimension: .estimated(bannerHeight)
+                heightDimension: .estimated(333)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(bannerWidthRatio),
-                heightDimension: .estimated(bannerHeight)
+                heightDimension: .estimated(333)
             )
             let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
             
             let section = NSCollectionLayoutSection(group: group)
             section.orthogonalScrollingBehavior = .groupPaging
+            section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
             section.interGroupSpacing = 16
             
             return section
         }
         return layout
+    }
+    
+    // MARK: Configure DataSource
+    private func configureDataSource() {
+        dataSource = .init(collectionView: hbtiSurveyResultCollectionView, cellProvider: { (collectionView, indexPath, item) -> UICollectionViewCell? in
+            
+            switch item {
+            case .recommand(let note):
+                let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: HBTISurveyResultCell.identifier,
+                    for: indexPath) as! HBTISurveyResultCell
+                
+                cell.configureCell(note: note)
+                
+                return cell
+            }
+        })
+        
+        var initialSnapshot = NSDiffableDataSourceSnapshot<HBTISurveyResultSection, HBTISurveyResultItem>()
+        initialSnapshot.appendSections([.recommand])
+        initialSnapshot.appendItems([
+            .recommand(HBTISurveyResultNote(id: 1, name: "시트러스", photoURL: "", content: "귤, 베르가못, 만다린이 들어간 상큼한 향료로 향수에서 가장 많이 사용되는 노트입니다.")),
+            .recommand(HBTISurveyResultNote(id: 2, name: "플로럴", photoURL: "", content: "귤, 베르가못, 만다린이 들어간 상큼한 향료로 향수에서 가장 많이 사용되는 노트입니다.")),
+            .recommand(HBTISurveyResultNote(id: 3, name: "스파이스", photoURL: "", content: "귤, 베르가못, 만다린이 들어간 상큼한 향료로 향수에서 가장 많이 사용되는 노트입니다."))
+        ])
+        
+        dataSource?.apply(initialSnapshot, animatingDifferences: false)
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -82,6 +82,7 @@ class HBTISurveyResultViewController: UIViewController, View {
     
     private func setUI() {
         setBackItemNaviBar("향BTI")
+        hbtiSurveyResultCollectionView.isScrollEnabled = false
         loadingView.isHidden = true
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -42,6 +42,14 @@ class HBTISurveyResultViewController: UIViewController, View {
         )
     }
     
+    private let nextButton = UIButton().then {
+        $0.setTitle("다음", for: .normal)
+        $0.titleLabel?.font = .customFont(.pretendard, 15)
+        $0.setTitleColor(.white, for: .normal)
+        $0.layer.cornerRadius = 5
+        $0.backgroundColor = .black
+    }
+    
     // MARK: - Properties
     
     var disposeBag = DisposeBag()
@@ -86,7 +94,8 @@ class HBTISurveyResultViewController: UIViewController, View {
         [
             bestLabel,
             secondThirdLabel,
-            hbtiSurveyResultCollectionView
+            hbtiSurveyResultCollectionView,
+            nextButton
         ] .forEach { view.addSubview($0) }
     }
     
@@ -110,6 +119,12 @@ class HBTISurveyResultViewController: UIViewController, View {
             make.top.equalTo(secondThirdLabel.snp.bottom).offset(29)
             make.horizontalEdges.equalToSuperview()
             make.height.lessThanOrEqualTo(400)
+        }
+        
+        nextButton.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(16)
+            make.bottom.equalToSuperview().inset(40)
+            make.height.equalTo(52)
         }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -35,7 +35,12 @@ class HBTISurveyResultViewController: UIViewController, View {
     private lazy var hbtiSurveyResultCollectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: createLayout()
-    )
+    ).then {
+        $0.register(
+            HBTISurveyResultCell.self,
+            forCellWithReuseIdentifier: HBTISurveyResultCell.identifier
+        )
+    }
     
     // MARK: - Properties
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -1,0 +1,63 @@
+//
+//  HBTISurveyResultViewController.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 8/12/24.
+//
+
+import UIKit
+
+import SnapKit
+import ReactorKit
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+class HBTISurveyResultViewController: UIViewController, View {
+    
+    // MARK: - UI Components
+    
+    
+    
+    // MARK: - Properties
+    
+    var disposeBag = DisposeBag()
+    
+    // MARK: - LifeCycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+        setAddView()
+        setConstraints()
+    }
+    
+    // MARK: - Bind
+    
+    func bind(reactor: HBTISurveyResultReactor) {
+        
+        // MARK: Action
+        
+        
+        // MARK: State
+        
+    }
+    
+    // MARK: - Functions
+    
+    private func setUI() {
+        setBackItemNaviBar("향BTI")
+    }
+    
+    // MARK: Add Views
+    private func setAddView() {
+        
+    }
+    
+    // MARK: Set Constraints
+    private func setConstraints() {
+        
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -18,7 +18,7 @@ class HBTISurveyResultViewController: UIViewController, View {
     
     // MARK: - UI Components
     
-    
+    private let loadingView = HBTILoadingView()
     
     // MARK: - Properties
     
@@ -53,11 +53,13 @@ class HBTISurveyResultViewController: UIViewController, View {
     
     // MARK: Add Views
     private func setAddView() {
-        
+        view.addSubview(loadingView)
     }
     
     // MARK: Set Constraints
     private func setConstraints() {
-        
+        loadingView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -20,6 +20,18 @@ class HBTISurveyResultViewController: UIViewController, View {
     
     private let loadingView = HBTILoadingView()
     
+    private let bestLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard_bold, size: 20, color: .black)
+        $0.setTextWithLineHeight(text: "OOO님에게 딱 맞는 향료는\n'시트러스'입니다", lineHeight: 27)
+        $0.numberOfLines = 2
+    }
+    
+    private let secondThirdLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard, size: 14, color: .gray3)
+        $0.setTextWithLineHeight(text: "2위: 플로럴\n3위: 스파이스", lineHeight: 20)
+        $0.numberOfLines = 2
+    }
+    
     // MARK: - Properties
     
     var disposeBag = DisposeBag()
@@ -49,17 +61,35 @@ class HBTISurveyResultViewController: UIViewController, View {
     
     private func setUI() {
         setBackItemNaviBar("향BTI")
+        loadingView.isHidden = true
     }
     
     // MARK: Add Views
     private func setAddView() {
+        // 로딩 화면
         view.addSubview(loadingView)
+        
+        // 결과 화면
+        [
+            bestLabel,
+            secondThirdLabel
+        ] .forEach { view.addSubview($0) }
     }
     
     // MARK: Set Constraints
     private func setConstraints() {
         loadingView.snp.makeConstraints { make in
             make.center.equalToSuperview()
+        }
+        
+        bestLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).inset(20)
+            make.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).inset(16)
+        }
+        
+        secondThirdLabel.snp.makeConstraints { make in
+            make.top.equalTo(bestLabel.snp.bottom).offset(12)
+            make.leading.equalToSuperview().inset(16)
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -32,6 +32,11 @@ class HBTISurveyResultViewController: UIViewController, View {
         $0.numberOfLines = 2
     }
     
+    private lazy var hbtiSurveyResultCollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: createLayout()
+    )
+    
     // MARK: - Properties
     
     var disposeBag = DisposeBag()
@@ -91,5 +96,34 @@ class HBTISurveyResultViewController: UIViewController, View {
             make.top.equalTo(bestLabel.snp.bottom).offset(12)
             make.leading.equalToSuperview().inset(16)
         }
+    }
+    
+    // MARK: Create Layout
+    private func createLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout {
+            (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+            
+            let bannerWidthRatio = 249.0 / 360.0
+            let bannerHeight = 333.0 / 249.0 * bannerWidthRatio
+            
+            let itemSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .estimated(bannerHeight)
+            )
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            
+            let groupSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(bannerWidthRatio),
+                heightDimension: .estimated(bannerHeight)
+            )
+            let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+            
+            let section = NSCollectionLayoutSection(group: group)
+            section.orthogonalScrollingBehavior = .groupPaging
+            section.interGroupSpacing = 16
+            
+            return section
+        }
+        return layout
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
@@ -48,7 +48,7 @@ class HomeViewController: UIViewController, View {
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        presentHBTIViewController()
+        presentHBTISurveyResultViewController()
         configureUI()
         setSearchBellNaviBar("H  M  O  A", bellButton: bellBarButton)
         configureCollectionViewDataSource()

--- a/HMOA_iOS/Podfile
+++ b/HMOA_iOS/Podfile
@@ -24,6 +24,7 @@ target 'HMOA_iOS' do
   pod 'FirebaseFirestore'
   pod 'FirebaseMessaging'
   pod 'FirebaseCrashlytics'
+  pod 'Gifu'
   use_frameworks!
 
   # Pods for HMOA_iOS

--- a/HMOA_iOS/Podfile.lock
+++ b/HMOA_iOS/Podfile.lock
@@ -1048,6 +1048,7 @@ PODS:
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesSwift (~> 2.1)
   - FirebaseSharedSwift (10.25.0)
+  - Gifu (3.3.1)
   - GoogleAppMeasurement (10.25.0):
     - GoogleAppMeasurement/AdIdSupport (= 10.25.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
@@ -1267,6 +1268,7 @@ DEPENDENCIES:
   - FirebaseCrashlytics
   - FirebaseFirestore
   - FirebaseMessaging
+  - Gifu
   - GoogleSignIn
   - Kingfisher
   - ReactorKit
@@ -1303,6 +1305,7 @@ SPEC REPOS:
     - FirebaseRemoteConfigInterop
     - FirebaseSessions
     - FirebaseSharedSwift
+    - Gifu
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleSignIn
@@ -1358,6 +1361,7 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: b25018791b204c0d78a90e394d6c62d9b1f22da8
   FirebaseSessions: c0939656253a1fa0e94ecc266ccf770cc8b33732
   FirebaseSharedSwift: 0274086954b1b2d5fd7e829eccc587044d72a4ba
+  Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   GoogleAppMeasurement: 9abf64b682732fed36da827aa2a68f0221fd2356
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
@@ -1393,6 +1397,6 @@ SPEC CHECKSUMS:
   Then: 844265ae87834bbe1147d91d5d41a404da2ec27d
   WeakMapTable: 05c694ce8439a7a9ebabb56187287a63c57673d6
 
-PODFILE CHECKSUM: 54eb7f3359b50dc3d5e48f23f251dc6347ae6d86
+PODFILE CHECKSUM: e3ee790c1fcc485b7052578b5873a5116671fcf1
 
 COCOAPODS: 1.14.3


### PR DESCRIPTION
# 📌 이슈번호
- #195

# 📌 구현/추가 사항
- 향BTI 설문 후 결과화면의 UI 컴포넌트 작업을 완료했습니다.
- 결과VC에 로딩View와 결과View를 모두 포함시켜, 한 쪽을 hidden 처리하는 방식으로 진행할 예정입니다.
- 로딩 애니메이션을 gif 파일로 적용하자는 의견이 제시됨에 따라 Gifu 라이브러리를 사용했습니다. 
- gif 파일은 아직 미완성이라 받지 못해서 임시 파일을 적용해두었습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/a06da408-da9c-4dec-bb8f-c0aa0d343db3

https://github.com/user-attachments/assets/e62c603c-8a04-46c5-bd09-36012e58388a



