### PR TITLE
[Feat] 향BTI 메인화면 상호작용

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		C904BFA22BA95CF000B28494 /* MagazineLikeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C904BFA12BA95CF000B28494 /* MagazineLikeCell.swift */; };
 		C904BFA42BA9616200B28494 /* MagazineContentsHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C904BFA32BA9616100B28494 /* MagazineContentsHeaderCell.swift */; };
 		C904BFA62BA9617E00B28494 /* MagazineContentsImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C904BFA52BA9617E00B28494 /* MagazineContentsImageCell.swift */; };
+		C91980E52C6D947300A7E91F /* HBTINoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91980E42C6D947300A7E91F /* HBTINoteViewController.swift */; };
+		C91980E72C6D952600A7E91F /* HBTINoteReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91980E62C6D952500A7E91F /* HBTINoteReactor.swift */; };
 		C93BFA6D2C428E9300A5D9D2 /* IntroViewHBTI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA6C2C428E9300A5D9D2 /* IntroViewHBTI.swift */; };
 		C93BFA762C4295FC00A5D9D2 /* HBTISurveyReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA6F2C4295FC00A5D9D2 /* HBTISurveyReactor.swift */; };
 		C93BFA782C4295FC00A5D9D2 /* HBTISurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA742C4295FC00A5D9D2 /* HBTISurveyViewController.swift */; };
@@ -427,6 +429,8 @@
 		C904BFA12BA95CF000B28494 /* MagazineLikeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineLikeCell.swift; sourceTree = "<group>"; };
 		C904BFA32BA9616100B28494 /* MagazineContentsHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineContentsHeaderCell.swift; sourceTree = "<group>"; };
 		C904BFA52BA9617E00B28494 /* MagazineContentsImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineContentsImageCell.swift; sourceTree = "<group>"; };
+		C91980E42C6D947300A7E91F /* HBTINoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTINoteViewController.swift; sourceTree = "<group>"; };
+		C91980E62C6D952500A7E91F /* HBTINoteReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTINoteReactor.swift; sourceTree = "<group>"; };
 		C93BFA6C2C428E9300A5D9D2 /* IntroViewHBTI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewHBTI.swift; sourceTree = "<group>"; };
 		C93BFA6F2C4295FC00A5D9D2 /* HBTISurveyReactor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HBTISurveyReactor.swift; sourceTree = "<group>"; };
 		C93BFA742C4295FC00A5D9D2 /* HBTISurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HBTISurveyViewController.swift; sourceTree = "<group>"; };
@@ -1448,6 +1452,47 @@
 			path = ContentsCell;
 			sourceTree = "<group>";
 		};
+		C91980DF2C6D93EF00A7E91F /* HBTINote */ = {
+			isa = PBXGroup;
+			children = (
+				C91980E02C6D943500A7E91F /* Model */,
+				C91980E12C6D943C00A7E91F /* Reactor */,
+				C91980E22C6D944200A7E91F /* View */,
+				C91980E32C6D944700A7E91F /* ViewController */,
+			);
+			path = HBTINote;
+			sourceTree = "<group>";
+		};
+		C91980E02C6D943500A7E91F /* Model */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		C91980E12C6D943C00A7E91F /* Reactor */ = {
+			isa = PBXGroup;
+			children = (
+				C91980E62C6D952500A7E91F /* HBTINoteReactor.swift */,
+			);
+			path = Reactor;
+			sourceTree = "<group>";
+		};
+		C91980E22C6D944200A7E91F /* View */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		C91980E32C6D944700A7E91F /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				C91980E42C6D947300A7E91F /* HBTINoteViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
 		C93BFA6B2C428DAA00A5D9D2 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -1709,6 +1754,7 @@
 				C93CA20D2C69E6A900AFD9E8 /* HBTISurveyResult */,
 				C96F760D2C40065600D44773 /* HBTI */,
 				C93BFA6E2C4295C200A5D9D2 /* HBTISurvey */,
+				C91980DF2C6D93EF00A7E91F /* HBTINote */,
 			);
 			path = HBTI;
 			sourceTree = "<group>";
@@ -2891,11 +2937,13 @@
 				C96B99D22BB022B6005F4E31 /* MagazineTagCell.swift in Sources */,
 				2C04247129A3E3D4009CF0FE /* FirstDetail.swift in Sources */,
 				2C4CDC4B29C770D900676163 /* BrandSearchViewController.swift in Sources */,
+				C91980E72C6D952600A7E91F /* HBTINoteReactor.swift in Sources */,
 				CA7640122AA864630053076B /* DictionaryViewController.swift in Sources */,
 				2C710EED29798172006BE23B /* HomeFirstCell.swift in Sources */,
 				2C4A265D29C2F6F3009F288F /* ServiceAPI.swift in Sources */,
 				CAD1EC132A812491003B21FD /* NoLoginView.swift in Sources */,
 				CA01609D2AB2E46000D5839D /* EvaluationAddress.swift in Sources */,
+				C91980E52C6D947300A7E91F /* HBTINoteViewController.swift in Sources */,
 				2C39AA16296DB4DE000C6F71 /* AppDelegate.swift in Sources */,
 				2CF5C1A62A51A9D200C2FA32 /* ChangeProfileImageViewController.swift in Sources */,
 				2C04247F29A4C329009CF0FE /* CommentListViewController.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -290,6 +290,14 @@ extension UIViewController {
         hbtiSurveyResultVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(hbtiSurveyResultVC, animated: true)
     }
+        
+    /// HBTINoteVC로 push
+    func presentHBTINoteViewController() {
+        let hbtiNoteVC = HBTINoteViewController()
+        hbtiNoteVC.reactor = HBTINoteReactor()
+        hbtiNoteVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(hbtiNoteVC, animated: true)
+    }
     
     // MARK: Configure NavigationBar
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
@@ -10,15 +10,15 @@ import RxSwift
 class HBTIReactor: Reactor {
     
     enum Action {
-        
+        case didTapSurveyButton
     }
     
     enum Mutation {
-        
+        case setIsTapSurveyButton(Bool)
     }
     
     struct State {
-        
+        var isTapSurveyButton: Bool = false
     }
     
     var initialState: State
@@ -28,10 +28,23 @@ class HBTIReactor: Reactor {
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
-        
+        switch action {
+        case .didTapSurveyButton:
+            return .concat([
+                .just(.setIsTapSurveyButton(true)),
+                .just(.setIsTapSurveyButton(false))
+            ])
+        }
     }
     
     func reduce(state: State, mutation: Mutation) -> State {
+        var state = state
         
+        switch mutation {
+        case .setIsTapSurveyButton(let isTap):
+            state.isTapSurveyButton = isTap
+        }
+        
+        return state
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
@@ -11,14 +11,17 @@ class HBTIReactor: Reactor {
     
     enum Action {
         case didTapSurveyButton
+        case didTapNoteButton
     }
     
     enum Mutation {
         case setIsTapSurveyButton(Bool)
+        case setIsTapNoteButton(Bool)
     }
     
     struct State {
         var isTapSurveyButton: Bool = false
+        var isTapNoteButton: Bool = false
     }
     
     var initialState: State
@@ -34,6 +37,12 @@ class HBTIReactor: Reactor {
                 .just(.setIsTapSurveyButton(true)),
                 .just(.setIsTapSurveyButton(false))
             ])
+            
+        case .didTapNoteButton:
+            return .concat([
+                .just(.setIsTapNoteButton(true)),
+                .just(.setIsTapNoteButton(false))
+            ])
         }
     }
     
@@ -43,6 +52,9 @@ class HBTIReactor: Reactor {
         switch mutation {
         case .setIsTapSurveyButton(let isTap):
             state.isTapSurveyButton = isTap
+            
+        case .setIsTapNoteButton(let isTap):
+            state.isTapNoteButton = isTap
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
@@ -7,7 +7,7 @@
 import ReactorKit
 import RxSwift
 
-class HBTIReactor: Reactor {
+final class HBTIReactor: Reactor {
     
     enum Action {
         case didTapSurveyButton

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/View/HBTIHomeBottomView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/View/HBTIHomeBottomView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HBTIHomeBottomView: UIView {
+final class HBTIHomeBottomView: UIView {
 
     // MARK: - UI Components
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/View/HBTIHomeTopView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/View/HBTIHomeTopView.swift
@@ -31,9 +31,9 @@ class HBTIHomeTopView: UIView {
         $0.distribution = .fillEqually
     }
     
-    private let goToSurveyButton = UIButton()
+    let goToSurveyButton = UIButton()
     
-    private let selectSpiceButton = UIButton()
+    let selectSpiceButton = UIButton()
     
     // MARK: - Init
     
@@ -92,7 +92,7 @@ class HBTIHomeTopView: UIView {
         }
     }
     
-    func configureButton(_ button: UIButton, withTitle title: String, imageName: String) {
+    private func configureButton(_ button: UIButton, withTitle title: String, imageName: String) {
         button.titleLabel?.numberOfLines = 0
         button.setTitleColor(.black, for: .normal)
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/View/HBTIHomeTopView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/View/HBTIHomeTopView.swift
@@ -33,7 +33,7 @@ class HBTIHomeTopView: UIView {
     
     let goToSurveyButton = UIButton()
     
-    let selectSpiceButton = UIButton()
+    let selectNoteButton = UIButton()
     
     // MARK: - Init
     
@@ -59,7 +59,7 @@ class HBTIHomeTopView: UIView {
         )
         
         configureButton(
-            selectSpiceButton,
+            selectNoteButton,
             withTitle: "향료 입력하기\n(주문 후)",
             imageName: "selectSpice"
         )
@@ -71,7 +71,7 @@ class HBTIHomeTopView: UIView {
          buttonStackView
         ].forEach { self.addSubview($0) }
         
-        [goToSurveyButton, selectSpiceButton
+        [goToSurveyButton, selectNoteButton
         ].forEach { buttonStackView.addArrangedSubview($0)}
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/View/HBTIHomeTopView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/View/HBTIHomeTopView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class HBTIHomeTopView: UIView {
+final class HBTIHomeTopView: UIView {
     
     // MARK: - UI Components
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -45,10 +45,20 @@ class HBTIViewController: UIViewController, View {
     func bind(reactor: HBTIReactor) {
         
         // MARK: Action
-        
+        yourHBTIView.goToSurveyButton.rx.tap
+            .map { Reactor.Action.didTapSurveyButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         
         // MARK: State
-        
+        reactor.state
+            .map { $0.isTapSurveyButton }
+            .filter { $0 }
+            .asDriver(onErrorRecover: { _ in return .empty() })
+            .drive(with: self, onNext: { owner, type in
+                owner.presentHBTISurveyViewController()
+            })
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Functions

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -14,7 +14,7 @@ import RxSwift
 import SnapKit
 import Then
 
-class HBTIViewController: UIViewController, View {
+final class HBTIViewController: UIViewController, View {
     
     // MARK: - UI Components
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -59,19 +59,17 @@ final class HBTIViewController: UIViewController, View {
         reactor.state
             .map { $0.isTapSurveyButton }
             .filter { $0 }
+            .map { _ in }
             .asDriver(onErrorRecover: { _ in return .empty() })
-            .drive(with: self, onNext: { owner, type in
-                owner.presentHBTISurveyViewController()
-            })
+            .drive(onNext: presentHBTISurveyViewController)
             .disposed(by: disposeBag)
         
         reactor.state
             .map { $0.isTapNoteButton }
             .filter { $0 }
+            .map { _ in }
             .asDriver(onErrorRecover: { _ in return .empty() })
-            .drive(with: self, onNext: { owner, type in
-                owner.presentHBTINoteViewController()
-            })
+            .drive(onNext: presentHBTINoteViewController)
             .disposed(by: disposeBag)
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -50,6 +50,11 @@ class HBTIViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        yourHBTIView.selectNoteButton.rx.tap
+            .map { Reactor.Action.didTapNoteButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: State
         reactor.state
             .map { $0.isTapSurveyButton }
@@ -57,6 +62,15 @@ class HBTIViewController: UIViewController, View {
             .asDriver(onErrorRecover: { _ in return .empty() })
             .drive(with: self, onNext: { owner, type in
                 owner.presentHBTISurveyViewController()
+            })
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isTapNoteButton }
+            .filter { $0 }
+            .asDriver(onErrorRecover: { _ in return .empty() })
+            .drive(with: self, onNext: { owner, type in
+                owner.presentHBTINoteViewController()
             })
             .disposed(by: disposeBag)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINote/Reactor/HBTINoteReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINote/Reactor/HBTINoteReactor.swift
@@ -7,7 +7,7 @@
 import ReactorKit
 import RxSwift
 
-class HBTINoteReactor: Reactor {
+final class HBTINoteReactor: Reactor {
     
     enum Action {
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINote/Reactor/HBTINoteReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINote/Reactor/HBTINoteReactor.swift
@@ -1,0 +1,45 @@
+//
+//  HBTINoteReactor.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 8/15/24.
+//
+import ReactorKit
+import RxSwift
+
+class HBTINoteReactor: Reactor {
+    
+    enum Action {
+        
+    }
+    
+    enum Mutation {
+        
+    }
+    
+    struct State {
+        
+    }
+    
+    var initialState: State
+    
+    init() {
+        self.initialState = State()
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+            
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var state = state
+        
+        switch mutation {
+            
+        }
+        
+        return state
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINote/ViewController/HBTINoteViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINote/ViewController/HBTINoteViewController.swift
@@ -25,6 +25,8 @@ class HBTINoteViewController: UIViewController, View {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // TODO: setUI 함수로 옮기기
+        view.backgroundColor = .white
     }
     
     func bind(reactor: HBTINoteReactor) {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINote/ViewController/HBTINoteViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINote/ViewController/HBTINoteViewController.swift
@@ -1,0 +1,39 @@
+//
+//  HBTINoteViewController.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 8/15/24.
+//
+
+import UIKit
+
+import SnapKit
+import ReactorKit
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+class HBTINoteViewController: UIViewController, View {
+    
+    // MARK: - Properties
+    
+    var disposeBag = DisposeBag()
+    
+    // MARK: - LifeCycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+    
+    func bind(reactor: HBTINoteReactor) {
+        
+        // MARK: Action
+        
+        
+        // MARK: State
+        
+    }
+
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINote/ViewController/HBTINoteViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINote/ViewController/HBTINoteViewController.swift
@@ -14,7 +14,7 @@ import RxSwift
 import SnapKit
 import Then
 
-class HBTINoteViewController: UIViewController, View {
+final class HBTINoteViewController: UIViewController, View {
     
     // MARK: - Properties
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/Reactor/HBTISurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/Reactor/HBTISurveyReactor.swift
@@ -8,7 +8,7 @@
 import ReactorKit
 import RxSwift
 
-class HBTISurveyReactor: Reactor {
+final class HBTISurveyReactor: Reactor {
     
     enum Action {
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/View/HBTISurveyAnswerButton.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/View/HBTISurveyAnswerButton.swift
@@ -10,7 +10,7 @@ import UIKit
 import Then
 import SnapKit
 
-class HBTISurveyAnswerButton: UIButton {
+final class HBTISurveyAnswerButton: UIButton {
     
     // MARK: - UI Components
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/View/HBTISurveyQuestionCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/View/HBTISurveyQuestionCell.swift
@@ -10,7 +10,7 @@ import UIKit
 import Then
 import SnapKit
 
-class HBTISurveyQuestionCell: UICollectionViewCell {
+final class HBTISurveyQuestionCell: UICollectionViewCell {
     
     static let identifier = "HBTISurveyQuestionCell"
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
@@ -13,7 +13,7 @@ import RxSwift
 import SnapKit
 import Then
 
-class HBTISurveyViewController: UIViewController, View {
+final class HBTISurveyViewController: UIViewController, View {
     
     // MARK: - UI Components
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
@@ -73,6 +73,7 @@ class HBTISurveyViewController: UIViewController, View {
     
     // MARK: Set UI
     private func setUI() {
+        view.backgroundColor = .white
         setBackItemNaviBar("향BTI")
         hbtiSurveyCollectionView.isScrollEnabled = false
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
@@ -7,7 +7,7 @@
 import ReactorKit
 import RxSwift
 
-class HBTISurveyResultReactor: Reactor {
+final class HBTISurveyResultReactor: Reactor {
     
     enum Action {
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTILoadingView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTILoadingView.swift
@@ -11,7 +11,7 @@ import Gifu
 import SnapKit
 import Then
 
-class HBTILoadingView: UIView {
+final class HBTILoadingView: UIView {
 
     // MARK: - UI Components
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
@@ -11,7 +11,7 @@ import Kingfisher
 import Then
 import SnapKit
 
-class HBTISurveyResultCell: UICollectionViewCell {
+final class HBTISurveyResultCell: UICollectionViewCell {
     
     static let identifier = "HBTISurveyResultCell"
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -14,7 +14,7 @@ import RxSwift
 import SnapKit
 import Then
 
-class HBTISurveyResultViewController: UIViewController, View {
+final class HBTISurveyResultViewController: UIViewController, View {
     
     // MARK: - UI Components
     


### PR DESCRIPTION
# 📌 이슈번호
- #203

# 📌 구현/추가 사항
- HBTI 메인 화면에서 '향BTI 검사하러 가기', '향료 입력하기(주문 후)' 버튼으로 각각 HBTISurveyVC, HBTINoteVC로 push 하는 동작을 구현했습니다.
- 향BTI 2차 명세에 해당하는 HBTINoteVC는 임시로 만들어두었습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/959bb471-9576-489e-acec-df9761f71d21
