### PR TITLE
[New Feature] 향BTI 설문 결과화면 상호작용

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -161,10 +161,10 @@
 		C99E7B692BA96DE200F359BC /* MagazineDetailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99E7B682BA96DE200F359BC /* MagazineDetailItem.swift */; };
 		C99E7B6B2BA9F0B500F359BC /* MagazineDetailLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99E7B6A2BA9F0B500F359BC /* MagazineDetailLineView.swift */; };
 		C9D161E52C1FF2550032FE78 /* IgnoerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D161E42C1FF2550032FE78 /* IgnoerData.swift */; };
-		C9D230072C69F583008ACB9B /* loading.gif in Resources */ = {isa = PBXBuildFile; fileRef = C9D230062C69F583008ACB9B /* loading.gif */; };
 		C9D2300B2C69F601008ACB9B /* HBTILoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */; };
 		C9D2300D2C6AE106008ACB9B /* HBTISurveyResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */; };
 		C9D2300F2C6AE63C008ACB9B /* HBTISurveyResultSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300E2C6AE63C008ACB9B /* HBTISurveyResultSection.swift */; };
+		C9DEC1E82C72DF34001A2E93 /* loading.gif in Resources */ = {isa = PBXBuildFile; fileRef = C9DEC1E72C72DF34001A2E93 /* loading.gif */; };
 		CA0027C52B2C5E7D001DEAE3 /* TutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */; };
 		CA0027C72B2C60F8001DEAE3 /* TutorialContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */; };
 		CA0160962AB0B11100D5839D /* SecondDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0160952AB0B11100D5839D /* SecondDetail.swift */; };
@@ -473,10 +473,10 @@
 		C99E7B682BA96DE200F359BC /* MagazineDetailItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineDetailItem.swift; sourceTree = "<group>"; };
 		C99E7B6A2BA9F0B500F359BC /* MagazineDetailLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineDetailLineView.swift; sourceTree = "<group>"; };
 		C9D161E42C1FF2550032FE78 /* IgnoerData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IgnoerData.swift; path = ../../../../../../../../../Downloads/IgnoerData.swift; sourceTree = "<group>"; };
-		C9D230062C69F583008ACB9B /* loading.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; name = loading.gif; path = ../../../../../../.Trash/loading.gif; sourceTree = "<group>"; };
 		C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTILoadingView.swift; sourceTree = "<group>"; };
 		C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTISurveyResultCell.swift; sourceTree = "<group>"; };
 		C9D2300E2C6AE63C008ACB9B /* HBTISurveyResultSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTISurveyResultSection.swift; sourceTree = "<group>"; };
+		C9DEC1E72C72DF34001A2E93 /* loading.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = loading.gif; sourceTree = "<group>"; };
 		CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialViewController.swift; sourceTree = "<group>"; };
 		CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialContentViewController.swift; sourceTree = "<group>"; };
 		CA0160952AB0B11100D5839D /* SecondDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondDetail.swift; sourceTree = "<group>"; };
@@ -870,8 +870,8 @@
 				CAF177082BB58BAF00A8F66E /* GoogleService-Info.plist */,
 				2C39AA7629704C2F000C6F71 /* Info.plist */,
 				2C39AA23296DB4E0000C6F71 /* LaunchScreen.storyboard */,
+				C9DEC1E72C72DF34001A2E93 /* loading.gif */,
 				2C39AA21296DB4E0000C6F71 /* Assets.xcassets */,
-				C9D230062C69F583008ACB9B /* loading.gif */,
 				2C39AA1E296DB4DE000C6F71 /* HMOA_iOS.xcdatamodeld */,
 			);
 			path = Resource;
@@ -1537,6 +1537,39 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
+		C93CA2092C69E6A900AFD9E8 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				C9D2300E2C6AE63C008ACB9B /* HBTISurveyResultSection.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		C93CA20A2C69E6A900AFD9E8 /* Reactor */ = {
+			isa = PBXGroup;
+			children = (
+				C93CA2102C69EC6E00AFD9E8 /* HBTISurveyResultReactor.swift */,
+			);
+			path = Reactor;
+			sourceTree = "<group>";
+		};
+		C93CA20B2C69E6A900AFD9E8 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */,
+				C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		C93CA20C2C69E6A900AFD9E8 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				C93CA20E2C69E6D600AFD9E8 /* HBTISurveyResultViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
 		C93CA20D2C69E6A900AFD9E8 /* HBTISurveyResult */ = {
 			isa = PBXGroup;
 			children = (
@@ -1548,39 +1581,6 @@
 			path = HBTISurveyResult;
 			sourceTree = "<group>";
 		};
-        C93CA2092C69E6A900AFD9E8 /* Model */ = {
-            isa = PBXGroup;
-            children = (
-                C9D2300E2C6AE63C008ACB9B /* HBTISurveyResultSection.swift */,
-            );
-            path = Model;
-            sourceTree = "<group>";
-        };
-        C93CA20A2C69E6A900AFD9E8 /* Reactor */ = {
-            isa = PBXGroup;
-            children = (
-                C93CA2102C69EC6E00AFD9E8 /* HBTISurveyResultReactor.swift */,
-            );
-            path = Reactor;
-            sourceTree = "<group>";
-        };
-        C93CA20B2C69E6A900AFD9E8 /* View */ = {
-            isa = PBXGroup;
-            children = (
-                C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */,
-                C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */,
-            );
-            path = View;
-            sourceTree = "<group>";
-        };
-        C93CA20C2C69E6A900AFD9E8 /* ViewController */ = {
-            isa = PBXGroup;
-            children = (
-                C93CA20E2C69E6D600AFD9E8 /* HBTISurveyResultViewController.swift */,
-            );
-            path = ViewController;
-            sourceTree = "<group>";
-        };
 		C94EE0AA2C1FFB71005EDC95 /* PushAlarm */ = {
 			isa = PBXGroup;
 			children = (
@@ -2638,8 +2638,8 @@
 			files = (
 				CAA4245C2B6BF24D0005975D /* Settings.bundle in Resources */,
 				CAF177092BB58BAF00A8F66E /* GoogleService-Info.plist in Resources */,
+				C9DEC1E82C72DF34001A2E93 /* loading.gif in Resources */,
 				2C39AA25296DB4E0000C6F71 /* LaunchScreen.storyboard in Resources */,
-				C9D230072C69F583008ACB9B /* loading.gif in Resources */,
 				2C39AA22296DB4E0000C6F71 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
@@ -18,7 +18,7 @@ final class HBTISurveyResultReactor: Reactor {
     }
     
     struct State {
-        
+        var noteItems: [HBTISurveyResultItem] = [.recommand(HBTISurveyResultNote(id: 999, name: "시험용", photoURL: "시험용", content: "시험용"))]
     }
     
     var initialState: State
@@ -28,10 +28,16 @@ final class HBTISurveyResultReactor: Reactor {
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
-        
+        switch action {
+        }
     }
     
     func reduce(state: State, mutation: Mutation) -> State {
+        var state = state
         
+        switch mutation {
+        }
+        
+        return state
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
@@ -10,15 +10,16 @@ import RxSwift
 final class HBTISurveyResultReactor: Reactor {
     
     enum Action {
-        
+        case isTapNextButton
     }
     
     enum Mutation {
-        
+        case setIsPushNextVC
     }
     
     struct State {
         var noteItems: [HBTISurveyResultItem] = [.recommand(HBTISurveyResultNote(id: 999, name: "시험용", photoURL: "시험용", content: "시험용"))]
+        var isPushNextVC: Bool = false
     }
     
     var initialState: State
@@ -29,6 +30,8 @@ final class HBTISurveyResultReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .isTapNextButton:
+            return .just(.setIsPushNextVC)
         }
     }
     
@@ -36,6 +39,8 @@ final class HBTISurveyResultReactor: Reactor {
         var state = state
         
         switch mutation {
+        case .setIsPushNextVC:
+            state.isPushNextVC = true
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTILoadingView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTILoadingView.swift
@@ -18,7 +18,6 @@ final class HBTILoadingView: UIView {
     private let loadingImage = GIFImageView().then {
         $0.animate(withGIFNamed: "loading")
         $0.contentMode = .scaleAspectFit
-        $0.backgroundColor = UIColor.random
     }
     
     private let waitLabel = UILabel().then {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -75,8 +75,15 @@ final class HBTISurveyResultViewController: UIViewController, View {
         
         // MARK: Action
         
-        
         // MARK: State
+        reactor.state
+            .map { $0.noteItems }
+            .delay(.seconds(2), scheduler: MainScheduler.instance)
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, items in
+                owner.updateLoadingViewIsHidden(isHidden: !items.isEmpty)
+            })
+            .disposed(by: disposeBag)
         
     }
     
@@ -191,5 +198,12 @@ final class HBTISurveyResultViewController: UIViewController, View {
         ])
         
         dataSource?.apply(initialSnapshot, animatingDifferences: false)
+    }
+}
+
+extension HBTISurveyResultViewController {
+    private func updateLoadingViewIsHidden(isHidden: Bool) {
+        loadingView.isHidden = isHidden
+        resultView.isHidden = !isHidden
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -74,6 +74,10 @@ final class HBTISurveyResultViewController: UIViewController, View {
     func bind(reactor: HBTISurveyResultReactor) {
         
         // MARK: Action
+        nextButton.rx.tap
+            .map { Reactor.Action.isTapNextButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         
         // MARK: State
         reactor.state
@@ -83,6 +87,15 @@ final class HBTISurveyResultViewController: UIViewController, View {
             .drive(with: self, onNext: { owner, items in
                 owner.updateLoadingViewIsHidden(isHidden: !items.isEmpty)
             })
+            .disposed(by: disposeBag)
+        
+        // TODO: 향료 선택 가이드 VC로 push하도록 변경
+        reactor.state
+            .map { $0.isPushNextVC }
+            .filter { $0 }
+            .map { _ in }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(onNext: presentHBTINoteViewController)
             .disposed(by: disposeBag)
         
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -20,6 +20,8 @@ final class HBTISurveyResultViewController: UIViewController, View {
     
     private let loadingView = HBTILoadingView()
     
+    private let resultView = UIView()
+    
     private let bestLabel = UILabel().then {
         $0.setLabelUI("", font: .pretendard_bold, size: 20, color: .black)
         $0.setTextWithLineHeight(text: "OOO님에게 딱 맞는 향료는\n'시트러스'입니다", lineHeight: 27)
@@ -84,21 +86,22 @@ final class HBTISurveyResultViewController: UIViewController, View {
         view.backgroundColor = .white
         setBackItemNaviBar("향BTI")
         hbtiSurveyResultCollectionView.isScrollEnabled = false
-        loadingView.isHidden = true
+        resultView.isHidden = true
     }
     
     // MARK: Add Views
     private func setAddView() {
-        // 로딩 화면
-        view.addSubview(loadingView)
+        [
+            loadingView,
+            resultView
+        ] .forEach { view.addSubview($0) }
         
-        // 결과 화면
         [
             bestLabel,
             secondThirdLabel,
             hbtiSurveyResultCollectionView,
             nextButton
-        ] .forEach { view.addSubview($0) }
+        ] .forEach { resultView.addSubview($0) }
     }
     
     // MARK: Set Constraints
@@ -107,9 +110,13 @@ final class HBTISurveyResultViewController: UIViewController, View {
             make.center.equalToSuperview()
         }
         
+        resultView.snp.makeConstraints { make in
+            make.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+        
         bestLabel.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).inset(20)
-            make.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).inset(16)
+            make.top.equalToSuperview().inset(20)
+            make.leading.equalToSuperview().inset(16)
         }
         
         secondThirdLabel.snp.makeConstraints { make in


### PR DESCRIPTION
# 📌 이슈번호
- #213

# 📌 구현/추가 사항
- 설문 결과화면에서 데이터 로딩 로직, 다음 버튼 탭 액션을 구현했습니다.
- 다음 버튼은 원래 효택님께서 작업하시는 가이드VC로 push되도록 구현되어야 하지만, 작업을 병합하기 전이라 임시로 다른 VC를 push하도록 구현했습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/bcd44886-1eb8-4d29-8254-1b0393e2c708


