### PR TITLE
[New Feature] 향BTI 설문 화면 네트워킹

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		C904BFA62BA9617E00B28494 /* MagazineContentsImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C904BFA52BA9617E00B28494 /* MagazineContentsImageCell.swift */; };
 		C91980E52C6D947300A7E91F /* HBTINoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91980E42C6D947300A7E91F /* HBTINoteViewController.swift */; };
 		C91980E72C6D952600A7E91F /* HBTINoteReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91980E62C6D952500A7E91F /* HBTINoteReactor.swift */; };
+		C923018F2C7483E0002A95BE /* HBTIAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923018E2C7483E0002A95BE /* HBTIAddress.swift */; };
+		C92301912C7483EA002A95BE /* HBTIAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92301902C7483EA002A95BE /* HBTIAPI.swift */; };
 		C93BFA6D2C428E9300A5D9D2 /* IntroViewHBTI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA6C2C428E9300A5D9D2 /* IntroViewHBTI.swift */; };
 		C93BFA762C4295FC00A5D9D2 /* HBTISurveyReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA6F2C4295FC00A5D9D2 /* HBTISurveyReactor.swift */; };
 		C93BFA782C4295FC00A5D9D2 /* HBTISurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA742C4295FC00A5D9D2 /* HBTISurveyViewController.swift */; };
@@ -431,6 +433,8 @@
 		C904BFA52BA9617E00B28494 /* MagazineContentsImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineContentsImageCell.swift; sourceTree = "<group>"; };
 		C91980E42C6D947300A7E91F /* HBTINoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTINoteViewController.swift; sourceTree = "<group>"; };
 		C91980E62C6D952500A7E91F /* HBTINoteReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTINoteReactor.swift; sourceTree = "<group>"; };
+		C923018E2C7483E0002A95BE /* HBTIAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIAddress.swift; sourceTree = "<group>"; };
+		C92301902C7483EA002A95BE /* HBTIAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIAPI.swift; sourceTree = "<group>"; };
 		C93BFA6C2C428E9300A5D9D2 /* IntroViewHBTI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewHBTI.swift; sourceTree = "<group>"; };
 		C93BFA6F2C4295FC00A5D9D2 /* HBTISurveyReactor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HBTISurveyReactor.swift; sourceTree = "<group>"; };
 		C93BFA742C4295FC00A5D9D2 /* HBTISurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HBTISurveyViewController.swift; sourceTree = "<group>"; };
@@ -1807,6 +1811,8 @@
 			isa = PBXGroup;
 			children = (
 				C98424622C43D51700530259 /* Model */,
+				C923018E2C7483E0002A95BE /* HBTIAddress.swift */,
+				C92301902C7483EA002A95BE /* HBTIAPI.swift */,
 			);
 			path = HBTI;
 			sourceTree = "<group>";
@@ -2875,6 +2881,7 @@
 				CA0160982AB2E15200D5839D /* EvaluationReactor.swift in Sources */,
 				2C04249D29A65C32009CF0FE /* CommentWriteReactor.swift in Sources */,
 				CA22389B2AAF492D00452A31 /* CommunityPostCell.swift in Sources */,
+				C923018F2C7483E0002A95BE /* HBTIAddress.swift in Sources */,
 				CA6C48612B2C2F8C00F1BE7F /* TotalPerfumeAddress.swift in Sources */,
 				C9D2300B2C69F601008ACB9B /* HBTILoadingView.swift in Sources */,
 				CA99A6D12B1216DE0030364F /* ReportAPI.swift in Sources */,
@@ -2951,6 +2958,7 @@
 				CA2238932AAF420200452A31 /* CommunityDetailViewController.swift in Sources */,
 				CA1067DD29D6D39A009A7245 /* ChangeSexReactor.swift in Sources */,
 				CA1067D929D6C9A7009A7245 /* ChangeYearReactor.swift in Sources */,
+				C92301912C7483EA002A95BE /* HBTIAPI.swift in Sources */,
 				2C700DE829C1A84F00DDEF77 /* HomeHeaderReactor.swift in Sources */,
 				C96F760F2C4006F200D44773 /* HBTIHomeTopView.swift in Sources */,
 				CA39D5652B0B35F900694677 /* MyLogCommentViewController.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -284,9 +284,9 @@ extension UIViewController {
     }
     
     /// HBTISurveyResultVC로 push
-    func presentHBTISurveyResultViewController() {
+    func presentHBTISurveyResultViewController(_ selectedIDList: [Int]) {
         let hbtiSurveyResultVC = HBTISurveyResultViewController()
-        hbtiSurveyResultVC.reactor = HBTISurveyResultReactor()
+        hbtiSurveyResultVC.reactor = HBTISurveyResultReactor(selectedIDList)
         hbtiSurveyResultVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(hbtiSurveyResultVC, animated: true)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
@@ -15,4 +15,14 @@ final class HBTIAPI {
             data: nil,
             model: HBTISurveyResponse.self)
     }
+    
+    static func postAnswers(params: [String: [Int]]) -> Observable<HBTISurveyResultResponse> {
+        let data = try? JSONSerialization.data(withJSONObject: params, options: .prettyPrinted)
+        
+        return networking(
+            urlStr: HBTIAddress.postAnswerList.url,
+            method: .post,
+            data: data,
+            model: HBTISurveyResultResponse.self)
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
@@ -1,0 +1,18 @@
+//
+//  HBTIAPI.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 8/20/24.
+//
+
+import RxSwift
+
+final class HBTIAPI {
+    static func fetchSurvey() -> Observable<HBTISurveyResponse> {
+        return networking(
+            urlStr: HBTIAddress.fetchQuestionList.url,
+            method: .get,
+            data: nil,
+            model: HBTISurveyResponse.self)
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
@@ -1,0 +1,19 @@
+//
+//  HBTIAddress.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 8/20/24.
+//
+
+import Foundation
+
+enum HBTIAddress {
+    case fetchQuestionList
+    
+    var url: String {
+        switch self {
+        case .fetchQuestionList:
+            return "survey/note"
+        }
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
@@ -9,11 +9,14 @@ import Foundation
 
 enum HBTIAddress {
     case fetchQuestionList
+    case postAnswerList
     
     var url: String {
         switch self {
         case .fetchQuestionList:
             return "survey/note"
+        case .postAnswerList:
+            return "survey/note/respond"
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
@@ -7,18 +7,31 @@
 
 import Foundation
 
-struct HBTISurveyResponse: Hashable {
+struct HBTISurveyResponse: Hashable, Codable {
     let title: String
     let questions: [HBTIQuestion]
 }
 
-struct HBTIQuestion: Hashable {
+struct HBTIQuestion: Hashable, Codable {
     let id: Int
     let content: String
     let answers: [HBTIAnswer]
+    let isMultipleChoice: Bool
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "questionId"
+        case content
+        case answers
+        case isMultipleChoice
+    }
 }
 
-struct HBTIAnswer: Hashable {
+struct HBTIAnswer: Hashable, Codable {
     let id: Int
     let content: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "optionId"
+        case content = "option"
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
@@ -35,3 +35,21 @@ struct HBTIAnswer: Hashable, Codable {
         case content = "option"
     }
 }
+
+struct HBTISurveyResultResponse: Hashable, Codable {
+    let recommendNotes: [HBTISurveyResultNote]
+}
+
+struct HBTISurveyResultNote: Hashable, Codable {
+    let id: Int
+    let name: String
+    let photoURL: String
+    let content: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "noteId"
+        case name = "noteName"
+        case photoURL = "notePhotoUrl"
+        case content
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/Reactor/HBTISurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/Reactor/HBTISurveyReactor.swift
@@ -86,7 +86,6 @@ final class HBTISurveyReactor: Reactor {
             } else {
                 state.selectedID[questionID] = answerID
             }
-            state.selectedID[questionID] = answerID
             
         case .setNextQuestion(let row):
             // TODO: API 연동 후 조건문 변경

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/Reactor/HBTISurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/Reactor/HBTISurveyReactor.swift
@@ -20,7 +20,7 @@ final class HBTISurveyReactor: Reactor {
     enum Mutation {
         case setQuestionList([HBTISurveyItem])
         case setCurrentPage(Int)
-        case setSelectedID((HBTIQuestion, Int))
+        case setSelectedIDList((HBTIQuestion, Int))
         case setNextPage(Int)
         case setIsEnabledNextButton
         case setIsPushNextVC(Bool)
@@ -28,7 +28,7 @@ final class HBTISurveyReactor: Reactor {
     
     struct State {
         var questionList: [HBTISurveyItem] = []
-        var selectedID = [Int: [Int]]()
+        var selectedIDList = [Int: [Int]]()
         var currentPage: Int? = nil
         var isEnableNextButton: Bool = false
         var isPushNextVC: Bool = false
@@ -47,7 +47,7 @@ final class HBTISurveyReactor: Reactor {
             
         case .didTapAnswerButton(let (question, answerID)):
             return .concat([
-                .just(.setSelectedID((question, answerID))),
+                .just(.setSelectedIDList((question, answerID))),
                 .just(.setIsEnabledNextButton)
             ])
             
@@ -63,7 +63,7 @@ final class HBTISurveyReactor: Reactor {
             }
             let questionCount = currentState.questionList.count
             let isLastQuestion = currentQuestionIndexPath == questionCount - 1
-            let isAllSelected = currentState.selectedID.count == questionCount
+            let isAllSelected = currentState.selectedIDList.count == questionCount
             
             if isLastQuestion && isAllSelected {
                 return .just(.setIsPushNextVC(true))
@@ -83,22 +83,22 @@ final class HBTISurveyReactor: Reactor {
         case .setCurrentPage(let row):
             state.currentPage = row
             
-        case .setSelectedID(let (question, answerID)):
+        case .setSelectedIDList(let (question, answerID)):
             let questionID = question.id
             
-            guard let selectedID = state.selectedID[questionID] else {
-                state.selectedID[questionID] = [answerID]
+            guard let selectedID = state.selectedIDList[questionID] else {
+                state.selectedIDList[questionID] = [answerID]
                 break
             }
             
             if selectedID.contains(answerID) {
                 if selectedID.count == 1 {
-                    state.selectedID.removeValue(forKey: questionID)
+                    state.selectedIDList.removeValue(forKey: questionID)
                 } else {
-                    state.selectedID[questionID] = selectedID.filter { $0 != answerID }
+                    state.selectedIDList[questionID] = selectedID.filter { $0 != answerID }
                 }
             } else {
-                state.selectedID[questionID] = question.isMultipleChoice ? selectedID + [answerID] : [answerID]
+                state.selectedIDList[questionID] = question.isMultipleChoice ? selectedID + [answerID] : [answerID]
             }
             
         case .setNextPage(let page):
@@ -109,7 +109,7 @@ final class HBTISurveyReactor: Reactor {
             guard let currentPage = state.currentPage else { break }
             let question = state.questionList[currentPage].question!
             
-            state.isEnableNextButton = state.selectedID[question.id] != nil
+            state.isEnableNextButton = state.selectedIDList[question.id] != nil
             
         case .setIsPushNextVC(let isPush):
             state.isPushNextVC = isPush

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/View/HBTISurveyQuestionCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/View/HBTISurveyQuestionCell.swift
@@ -32,7 +32,7 @@ final class HBTISurveyQuestionCell: UICollectionViewCell {
     let answerStackView = UIStackView().then {
         $0.axis = .vertical
         $0.spacing = 16
-        $0.distribution = .equalSpacing
+        $0.distribution = .equalCentering
         $0.alignment = .fill
     }
     
@@ -70,7 +70,7 @@ final class HBTISurveyQuestionCell: UICollectionViewCell {
         
         answerStackView.snp.makeConstraints { make in
             make.top.equalTo(questionLabel.snp.bottom).offset(32)
-            make.horizontalEdges.bottom.equalToSuperview()
+            make.horizontalEdges.equalToSuperview()
         }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
@@ -128,7 +128,8 @@ final class HBTISurveyViewController: UIViewController, View {
     private func setUI() {
         view.backgroundColor = .white
         setBackItemNaviBar("향BTI")
-        hbtiSurveyCollectionView.isScrollEnabled = false
+        hbtiSurveyCollectionView.isScrollEnabled = true
+        hbtiSurveyCollectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 92, right: 0)
     }
     
     // MARK: Add Views
@@ -148,8 +149,7 @@ final class HBTISurveyViewController: UIViewController, View {
         
         hbtiSurveyCollectionView.snp.makeConstraints { make in
             make.top.equalTo(progressBar.snp.bottom).offset(32)
-            make.horizontalEdges.equalToSuperview()
-            make.bottom.equalTo(nextButton.snp.top)
+            make.horizontalEdges.bottom.equalToSuperview()
         }
         
         nextButton.snp.makeConstraints { make in
@@ -166,13 +166,13 @@ final class HBTISurveyViewController: UIViewController, View {
             
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1),
-                heightDimension: .estimated(600)
+                heightDimension: .fractionalHeight(1)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(0.92),
-                heightDimension: .estimated(600)
+                heightDimension: .fractionalHeight(1)
             )
             let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
             

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
@@ -94,7 +94,7 @@ final class HBTISurveyViewController: UIViewController, View {
             .disposed(by: disposeBag)
         
         reactor.state
-            .compactMap { $0.currentQuestion }
+            .compactMap { $0.currentPage }
             .distinctUntilChanged()
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, row in
@@ -184,7 +184,7 @@ final class HBTISurveyViewController: UIViewController, View {
                 let currentPage = Int(max(0, round(offset.x / env.container.contentSize.width)))
                 if currentPage != previousPage {
                     previousPage = currentPage
-                    self.reactor?.action.onNext(.didChangeQuestion(currentPage))
+                    self.reactor?.action.onNext(.didChangePage(currentPage))
                 }
             }
             

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
@@ -166,13 +166,13 @@ final class HBTISurveyViewController: UIViewController, View {
             
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1),
-                heightDimension: .estimated(300)
+                heightDimension: .estimated(600)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(0.92),
-                heightDimension: .estimated(300)
+                heightDimension: .estimated(600)
             )
             let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
             

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
@@ -63,12 +63,27 @@ final class HBTISurveyViewController: UIViewController, View {
     func bind(reactor: HBTISurveyReactor) {
         
         // MARK: Action
+        rx.viewDidLoad
+            .map { Reactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: self.disposeBag)
+        
         nextButton.rx.tap
             .map { Reactor.Action.didTapNextButton }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
         // MARK: State
+        
+        reactor.state
+            .map { $0.questionList }
+            .distinctUntilChanged()
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, items in
+                owner.updateSnapshot(forSection: .question, withItems: items)
+            })
+            .disposed(by: disposeBag)
+        
         reactor.state
             .map { $0.selectedID }
             .asDriver(onErrorRecover: { _ in .empty() })
@@ -218,52 +233,62 @@ final class HBTISurveyViewController: UIViewController, View {
         initialSnapshot.appendSections([.question])
         
         // TODO: API 연동 후 삭제
-        initialSnapshot.appendItems([
-            .question(HBTIQuestion(
-                id: 1,
-                content: "좋아하는 계절이 있으신가요?",
-                answers: [
-                    HBTIAnswer(id: 1, content: "싱그럽고 활기찬 ‘봄’"),
-                    HBTIAnswer(id: 2, content: "화창하고 에너지 넘치는 ‘여름’"),
-                    HBTIAnswer(id: 3, content: "우아하고 고요한 분위기의 ‘가을’"),
-                    HBTIAnswer(id: 4, content: "차가움과 아늑함이 공존하는 ‘겨울’")
-                ]
-            )),
-            .question(HBTIQuestion(
-                id: 2,
-                content: "남들이 생각하는 본인의 이미지는 무엇인가요?",
-                answers: [
-                    HBTIAnswer(id: 5, content: "청순"),
-                    HBTIAnswer(id: 6, content: "시크, 멋짐"),
-                    HBTIAnswer(id: 7, content: "단아"),
-                    HBTIAnswer(id: 8, content: "귀여움"),
-                    HBTIAnswer(id: 9, content: "섹시")
-                ]
-            )),
-            .question(HBTIQuestion(
-                id: 3,
-                content: "질문예시3",
-                answers: [
-                    HBTIAnswer(id: 10, content: "답1"),
-                    HBTIAnswer(id: 11, content: "답2"),
-                    HBTIAnswer(id: 12, content: "답3"),
-                    HBTIAnswer(id: 13, content: "답4"),
-                    HBTIAnswer(id: 14, content: "답5")
-                ]
-            )),
-            .question(HBTIQuestion(
-                id: 4,
-                content: "질문예시4",
-                answers: [
-                    HBTIAnswer(id: 15, content: "답6"),
-                    HBTIAnswer(id: 16, content: "답7"),
-                    HBTIAnswer(id: 17, content: "답8"),
-                    HBTIAnswer(id: 18, content: "답9"),
-                    HBTIAnswer(id: 19, content: "답10")
-                ]
-            ))
-        ], toSection: .question)
+//        initialSnapshot.appendItems([
+//            .question(HBTIQuestion(
+//                id: 1,
+//                content: "좋아하는 계절이 있으신가요?",
+//                answers: [
+//                    HBTIAnswer(id: 1, content: "싱그럽고 활기찬 ‘봄’"),
+//                    HBTIAnswer(id: 2, content: "화창하고 에너지 넘치는 ‘여름’"),
+//                    HBTIAnswer(id: 3, content: "우아하고 고요한 분위기의 ‘가을’"),
+//                    HBTIAnswer(id: 4, content: "차가움과 아늑함이 공존하는 ‘겨울’")
+//                ]
+//            )),
+//            .question(HBTIQuestion(
+//                id: 2,
+//                content: "남들이 생각하는 본인의 이미지는 무엇인가요?",
+//                answers: [
+//                    HBTIAnswer(id: 5, content: "청순"),
+//                    HBTIAnswer(id: 6, content: "시크, 멋짐"),
+//                    HBTIAnswer(id: 7, content: "단아"),
+//                    HBTIAnswer(id: 8, content: "귀여움"),
+//                    HBTIAnswer(id: 9, content: "섹시")
+//                ]
+//            )),
+//            .question(HBTIQuestion(
+//                id: 3,
+//                content: "질문예시3",
+//                answers: [
+//                    HBTIAnswer(id: 10, content: "답1"),
+//                    HBTIAnswer(id: 11, content: "답2"),
+//                    HBTIAnswer(id: 12, content: "답3"),
+//                    HBTIAnswer(id: 13, content: "답4"),
+//                    HBTIAnswer(id: 14, content: "답5")
+//                ]
+//            )),
+//            .question(HBTIQuestion(
+//                id: 4,
+//                content: "질문예시4",
+//                answers: [
+//                    HBTIAnswer(id: 15, content: "답6"),
+//                    HBTIAnswer(id: 16, content: "답7"),
+//                    HBTIAnswer(id: 17, content: "답8"),
+//                    HBTIAnswer(id: 18, content: "답9"),
+//                    HBTIAnswer(id: 19, content: "답10")
+//                ]
+//            ))
+//        ], toSection: .question)
         
         dataSource?.apply(initialSnapshot, animatingDifferences: false)
+    }
+    
+    private func updateSnapshot(forSection section: HBTISurveySection, withItems items: [HBTISurveyItem]) {
+        guard let dataSource = self.dataSource else { return }
+        
+        var snapshot = dataSource.snapshot()
+        
+        snapshot.appendItems(items, toSection: section)
+        
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurvey/ViewController/HBTISurveyViewController.swift
@@ -85,7 +85,7 @@ final class HBTISurveyViewController: UIViewController, View {
             .disposed(by: disposeBag)
         
         reactor.state
-            .map { $0.selectedID }
+            .map { $0.selectedIDList }
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, selectedID in
                 let progress = Float(selectedID.count) / Float(reactor.currentState.questionList.count)
@@ -115,9 +115,11 @@ final class HBTISurveyViewController: UIViewController, View {
         reactor.state
             .map { $0.isPushNextVC }
             .filter { $0 }
-            .map { _ in }
             .asDriver(onErrorRecover: { _ in .empty() })
-            .drive(onNext: presentHBTISurveyResultViewController)
+            .drive(with: self, onNext: { owner, isPush in
+                let list = reactor.currentState.selectedIDList.values.flatMap { $0 }
+                owner.presentHBTISurveyResultViewController(list)
+            })
             .disposed(by: disposeBag)
     }
     
@@ -218,7 +220,7 @@ final class HBTISurveyViewController: UIViewController, View {
                     
                     self.reactor?.state
                         .map {
-                            guard let selectedID = $0.selectedID[question.id] else { return false }
+                            guard let selectedID = $0.selectedIDList[question.id] else { return false }
                             return selectedID.contains(answerID)
                         }
                         .bind(to: button.rx.isSelected)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Model/HBTISurveyResultSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Model/HBTISurveyResultSection.swift
@@ -24,22 +24,3 @@ extension HBTISurveyResultItem {
         }
     }
 }
-
-// TODO: HBTI 설문 병합 후 이동
-struct HBTISurveyResultResponse: Hashable {
-    let recommandNotes: [HBTISurveyResultNote]
-}
-
-struct HBTISurveyResultNote: Hashable {
-    let id: Int
-    let name: String
-    let photoURL: String
-    let content: String
-    
-    enum CodingKeys: String, CodingKey {
-        case id = "noteId"
-        case name = "noteName"
-        case photoURL = "notePhotoUrl"
-        case content
-    }
-}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Model/HBTISurveyResultSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Model/HBTISurveyResultSection.swift
@@ -16,7 +16,7 @@ enum HBTISurveyResultItem: Hashable {
 }
 
 extension HBTISurveyResultItem {
-    var question: HBTISurveyResultNote? {
+    var note: HBTISurveyResultNote? {
         if case .recommand(let note) = self {
             return note
         } else {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Model/HBTISurveyResultSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Model/HBTISurveyResultSection.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum HBTISurveyResultSection: Hashable {
-    case recommand
+    case recommend
 }
 
 enum HBTISurveyResultItem: Hashable {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
@@ -18,14 +18,15 @@ final class HBTISurveyResultReactor: Reactor {
     }
     
     struct State {
+        var selectedIDList: [Int]
         var noteItems: [HBTISurveyResultItem] = [.recommand(HBTISurveyResultNote(id: 999, name: "시험용", photoURL: "시험용", content: "시험용"))]
         var isPushNextVC: Bool = false
     }
     
     var initialState: State
     
-    init() {
-        self.initialState = State()
+    init(_ selectedIDList: [Int]) {
+        self.initialState = State(selectedIDList: selectedIDList)
     }
     
     func mutate(action: Action) -> Observable<Mutation> {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTILoadingView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTILoadingView.swift
@@ -24,7 +24,7 @@ final class HBTILoadingView: UIView {
         $0.setLabelUI("잠시만 기다려주세요...", font: .pretendard, size: 16, color: .black)
     }
     
-    private let descriptionLabel = UILabel().then {
+    let descriptionLabel = UILabel().then {
         $0.setLabelUI("", font: .pretendard_bold, size: 22, color: .black)
         $0.setTextWithLineHeight(text: "OOO님에게 딱 맞는 \n향료를 추천하는 중입니다.", lineHeight: 28)
         $0.numberOfLines = 2

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
@@ -19,6 +19,7 @@ final class HBTISurveyResultCell: UICollectionViewCell {
     
     private let bannerImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFill
+        $0.clipsToBounds = true
     }
     
     private let nameLabel = UILabel().then {
@@ -79,8 +80,7 @@ final class HBTISurveyResultCell: UICollectionViewCell {
     }
     
     func configureCell(note: HBTISurveyResultNote) {
-//        bannerImageView.kf.setImage(with: URL(string: note.photoURL))
-        bannerImageView.backgroundColor = .random
+        bannerImageView.kf.setImage(with: URL(string: note.photoURL))
         nameLabel.text = note.name
         descriptionLabel.text = note.content
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/View/HBTISurveyResultCell.swift
@@ -28,9 +28,8 @@ final class HBTISurveyResultCell: UICollectionViewCell {
     
     private let descriptionLabel = UILabel().then {
         $0.setLabelUI("", font: .pretendard_light, size: 12, color: .white)
-        $0.setTextWithLineHeight(text: "설명\n2줄", lineHeight: 15)
-        $0.numberOfLines = 2
-        $0.lineBreakStrategy = .hangulWordPriority
+        $0.setTextWithLineHeight(text: "설명", lineHeight: 15)
+        $0.numberOfLines = 0
     }
     
     // MARK: - Init
@@ -75,7 +74,7 @@ final class HBTISurveyResultCell: UICollectionViewCell {
         descriptionLabel.snp.makeConstraints { make in
             make.top.equalTo(nameLabel.snp.bottom).offset(7)
             make.horizontalEdges.equalToSuperview().inset(20)
-            make.bottom.equalToSuperview().inset(24)
+            make.height.lessThanOrEqualTo(75)
         }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -178,13 +178,13 @@ final class HBTISurveyResultViewController: UIViewController, View {
             
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1),
-                heightDimension: .estimated(333)
+                heightDimension: .absolute(378)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(bannerWidthRatio),
-                heightDimension: .estimated(333)
+                heightDimension: .absolute(378)
             )
             let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
             

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -86,6 +86,12 @@ final class HBTISurveyResultViewController: UIViewController, View {
         
         // MARK: State
         reactor.state
+            .map { $0.resultInfo }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(onNext: updateLabels(with:))
+            .disposed(by: disposeBag)
+        
+        reactor.state
             .map { $0.noteItemList }
             .delay(.seconds(2), scheduler: MainScheduler.instance)
             .asDriver(onErrorRecover: { _ in .empty() })
@@ -223,5 +229,16 @@ extension HBTISurveyResultViewController {
     private func updateLoadingViewIsHidden(isHidden: Bool) {
         loadingView.isHidden = isHidden
         resultView.isHidden = !isHidden
+    }
+    
+    private func updateLabels(with resultInfo: [String: String]) {
+        guard let nickname = resultInfo["nickname"],
+              let best = resultInfo["best"],
+              let second = resultInfo["second"],
+              let third = resultInfo["third"] else { return }
+        
+        loadingView.descriptionLabel.text = "\(nickname)님에게 딱 맞는 \n향료를 추천하는 중입니다."
+        bestLabel.text = "\(nickname)님에게 딱 맞는 향료는\n'\(best)'입니다"
+        secondThirdLabel.text = "2위: \(second)\n3위: \(third)"
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -74,6 +74,11 @@ final class HBTISurveyResultViewController: UIViewController, View {
     func bind(reactor: HBTISurveyResultReactor) {
         
         // MARK: Action
+        rx.viewDidLoad
+            .map { Reactor.Action.viewDidLoad}
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         nextButton.rx.tap
             .map { Reactor.Action.isTapNextButton }
             .bind(to: reactor.action)
@@ -81,7 +86,7 @@ final class HBTISurveyResultViewController: UIViewController, View {
         
         // MARK: State
         reactor.state
-            .map { $0.noteItems }
+            .map { $0.noteItemList }
             .delay(.seconds(2), scheduler: MainScheduler.instance)
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, items in

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -96,6 +96,7 @@ final class HBTISurveyResultViewController: UIViewController, View {
             .delay(.seconds(2), scheduler: MainScheduler.instance)
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, items in
+                owner.updateSnapshot(forSection: .recommend, withItems: items)
                 owner.updateLoadingViewIsHidden(isHidden: !items.isEmpty)
             })
             .disposed(by: disposeBag)
@@ -214,14 +215,19 @@ final class HBTISurveyResultViewController: UIViewController, View {
         })
         
         var initialSnapshot = NSDiffableDataSourceSnapshot<HBTISurveyResultSection, HBTISurveyResultItem>()
-        initialSnapshot.appendSections([.recommand])
-        initialSnapshot.appendItems([
-            .recommand(HBTISurveyResultNote(id: 1, name: "시트러스", photoURL: "", content: "귤, 베르가못, 만다린이 들어간 상큼한 향료로 향수에서 가장 많이 사용되는 노트입니다.")),
-            .recommand(HBTISurveyResultNote(id: 2, name: "플로럴", photoURL: "", content: "귤, 베르가못, 만다린이 들어간 상큼한 향료로 향수에서 가장 많이 사용되는 노트입니다.")),
-            .recommand(HBTISurveyResultNote(id: 3, name: "스파이스", photoURL: "", content: "귤, 베르가못, 만다린이 들어간 상큼한 향료로 향수에서 가장 많이 사용되는 노트입니다."))
-        ])
+        initialSnapshot.appendSections([.recommend])
         
         dataSource?.apply(initialSnapshot, animatingDifferences: false)
+    }
+    
+    private func updateSnapshot(forSection section: HBTISurveyResultSection, withItems items: [HBTISurveyResultItem]) {
+        guard let dataSource = self.dataSource else { return }
+        
+        var snapshot = dataSource.snapshot()
+        
+        snapshot.appendItems(items, toSection: section)
+        
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
@@ -48,7 +48,7 @@ class HomeViewController: UIViewController, View {
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        presentHBTIViewController()
+        
         configureUI()
         setSearchBellNaviBar("H  M  O  A", bellButton: bellBarButton)
         configureCollectionViewDataSource()
@@ -56,6 +56,8 @@ class HomeViewController: UIViewController, View {
         
         navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         navigationController?.interactivePopGestureRecognizer?.delegate = self
+        
+        presentHBTIViewController()
     }
     
     private func configureUI() {


### PR DESCRIPTION
# 📌 이슈번호
- #218

# 📌 구현/추가 사항
- 향BTI 설문, 설문결과 화면에서의 서버 API 연동 작업을 완료했습니다.
- 설문결과 화면에서 라벨을 업데이트하기 위해 nickname과 note이름 정보를 담은 딕셔너리 state를 사용했는데, 더 좋은 방법이 있으면 피드백 부탁드립니다.

# 📷 미리보기
https://github.com/user-attachments/assets/f2afd11e-ef9b-4715-8020-13ef032ab0fe


