### PR TITLE
[Bug] 향BTI 1차 초반부 버그 등 해결

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/Home/HBTI/Arrow Back.svg
+++ b/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/Home/HBTI/Arrow Back.svg
@@ -1,0 +1,10 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8316_809)">
+<path d="M14.4199 20L4.41992 10L14.4199 0L15.5758 1.12903L6.70487 10L15.5758 18.871L14.4199 20Z" fill="white"/>
+</g>
+<defs>
+<clipPath id="clip0_8316_809">
+<rect width="20" height="20" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/Home/HBTI/whiteBack.imageset/Arrow Back.svg
+++ b/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/Home/HBTI/whiteBack.imageset/Arrow Back.svg
@@ -1,0 +1,10 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8316_809)">
+<path d="M14.4199 20L4.41992 10L14.4199 0L15.5758 1.12903L6.70487 10L15.5758 18.871L14.4199 20Z" fill="white"/>
+</g>
+<defs>
+<clipPath id="clip0_8316_809">
+<rect width="20" height="20" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/Home/HBTI/whiteBack.imageset/Contents.json
+++ b/HMOA_iOS/HMOA_iOS/Resource/Assets.xcassets/Home/HBTI/whiteBack.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "Arrow Back.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -415,6 +415,7 @@ extension UIViewController {
         self.navigationController?.navigationBar.scrollEdgeAppearance = scrollEdgeAppearance
     }
     
+    // 투명 배경과 back버튼 Navigation Bar
     func setClearBackNaviBar(_ title: String, _ titleColor: UIColor) {
         let titleLabel = UILabel().then {
             $0.text = title
@@ -436,10 +437,10 @@ extension UIViewController {
             NSAttributedString.Key.foregroundColor: UIColor.white
         ]
         
-        
         self.navigationController?.navigationBar.scrollEdgeAppearance = scrollEdgeAppearance
     }
     
+    // 투명 배경과 흰색 back버튼 NavigationBar
     func setClearWhiteBackNaviBar(_ title: String, _ titleColor: UIColor) {
         let titleLabel = UILabel().then {
             $0.text = title
@@ -461,8 +462,21 @@ extension UIViewController {
             NSAttributedString.Key.foregroundColor: UIColor.white
         ]
         
-        
         self.navigationController?.navigationBar.scrollEdgeAppearance = scrollEdgeAppearance
+    }
+    
+    /// 향BTI 홈으로 이동하는 Back버튼 Navigation Bar
+    func setBackToHBTIVCNaviBar(_ title: String) {
+        let titleLabel = UILabel().then {
+            $0.text = title
+            $0.font = .customFont(.pretendard_medium, 20)
+            $0.textColor = .black
+        }
+        
+        let backButton = self.navigationItem.makeImageButtonItem(self, action: #selector(popToHBTIViewController), imageName: "backButton")
+        
+        self.navigationItem.titleView = titleLabel
+        self.navigationItem.leftBarButtonItems = [backButton]
     }
     
     /// Back 버튼, Share 버튼 NavigationBar
@@ -568,6 +582,18 @@ extension UIViewController {
     /// 알림 권한 요청 및 On/Off
     @objc func pushAlarmSetting() {
         // TODO: 알림 권한 요청 및 On/Off 기능 구현
+    }
+    
+    // 향BTI 홈으로 이동
+    @objc func popToHBTIViewController() {
+        if let viewControllers = navigationController?.viewControllers {
+            for vc in viewControllers {
+                if vc is HBTIViewController {
+                    navigationController?.popToViewController(vc, animated: true)
+                    break
+                }
+            }
+        }
     }
     
     // MARK: - UI Function

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -440,6 +440,31 @@ extension UIViewController {
         self.navigationController?.navigationBar.scrollEdgeAppearance = scrollEdgeAppearance
     }
     
+    func setClearWhiteBackNaviBar(_ title: String, _ titleColor: UIColor) {
+        let titleLabel = UILabel().then {
+            $0.text = title
+            $0.font = .customFont(.pretendard_medium, 20)
+            $0.textColor = titleColor
+        }
+        
+        let backButton = self.navigationItem.makeImageButtonItem(self, action: #selector(popViewController), imageName: "whiteBack")
+        
+        self.navigationItem.titleView = titleLabel
+        self.navigationItem.leftBarButtonItems = [backButton]
+
+        let scrollEdgeAppearance = UINavigationBarAppearance()
+        scrollEdgeAppearance.backgroundColor = .clear
+        scrollEdgeAppearance.shadowColor = .clear
+        scrollEdgeAppearance.backgroundEffect = nil
+        scrollEdgeAppearance.titleTextAttributes = [
+            NSAttributedString.Key.font: UIFont.customFont(.pretendard_bold, 20),
+            NSAttributedString.Key.foregroundColor: UIColor.white
+        ]
+        
+        
+        self.navigationController?.navigationBar.scrollEdgeAppearance = scrollEdgeAppearance
+    }
+    
     /// Back 버튼, Share 버튼 NavigationBar
         func setBackShareRightNaviBar(_ title: String) {
             let titleLabel = UILabel().then {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -76,7 +76,7 @@ final class HBTIViewController: UIViewController, View {
     // MARK: - Functions
     
     private func setUI() {
-        setClearBackNaviBar("향BTI", .white)
+        setClearWhiteBackNaviBar("향BTI", .white)
     }
     
     // MARK: Add Views

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
@@ -16,14 +16,14 @@ final class HBTISurveyResultReactor: Reactor {
     
     enum Mutation {
         case setNoteItemList([HBTISurveyResultItem])
-        case setResultInfo(String)
+        case setNickname(String)
         case setIsPushNextVC
     }
     
     struct State {
         var selectedIDList: [Int]
         var noteItemList: [HBTISurveyResultItem] = []
-        var resultInfo: [String: String] = [:]
+        var nickname: String = ""
         var isPushNextVC: Bool = false
     }
     
@@ -37,8 +37,8 @@ final class HBTISurveyResultReactor: Reactor {
         switch action {
         case .viewDidLoad:
             return .concat([
-                setNoteItemList(),
-                setResultInfo()
+                setNickname(),
+                setNoteItemList()
             ])
         case .isTapNextButton:
             return .just(.setIsPushNextVC)
@@ -51,15 +51,9 @@ final class HBTISurveyResultReactor: Reactor {
         switch mutation {
         case .setNoteItemList(let item):
             state.noteItemList = item
-        case .setResultInfo(let nickname):
-            let noteList = currentState.noteItemList.map { $0.note!.name }
-            let resultInfo = [
-                "nickname": nickname,
-                "best": noteList.first!,
-                "second": noteList[1],
-                "third": noteList[2]
-            ]
-            state.resultInfo = resultInfo
+            
+        case .setNickname(let nickname):
+            state.nickname = nickname
             
         case .setIsPushNextVC:
             state.isPushNextVC = true
@@ -83,13 +77,13 @@ extension HBTISurveyResultReactor {
             }
     }
     
-    func setResultInfo() -> Observable<Mutation> {
+    func setNickname() -> Observable<Mutation> {
         return MemberAPI.getMember()
             .catch { _ in .empty() }
             .flatMap { member -> Observable<Mutation> in
                 guard let member = member else { return .empty() }
                 let nickname = member.nickname
-                return .just(.setResultInfo(nickname))
+                return .just(.setNickname(nickname))
             }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/ViewController/HBTISurveyResultViewController.swift
@@ -116,7 +116,7 @@ final class HBTISurveyResultViewController: UIViewController, View {
     
     private func setUI() {
         view.backgroundColor = .white
-        setBackItemNaviBar("향BTI")
+        setBackToHBTIVCNaviBar("향BTI")
         hbtiSurveyResultCollectionView.isScrollEnabled = false
         resultView.isHidden = true
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
@@ -18,6 +18,7 @@ final class HomeViewReactor: Reactor {
         case scrollCollectionView
         case didTapBellButton
         case settingIsLogin(Bool)
+        case didTapHBTIButton
     }
     
     enum Mutation {
@@ -28,6 +29,7 @@ final class HomeViewReactor: Reactor {
         case setIsTapWhenNotLogin(Bool?)
         case success
         case setIsLogin(Bool)
+        case setIsTapHBTI(Bool)
     }
     
     struct State {
@@ -37,6 +39,7 @@ final class HomeViewReactor: Reactor {
         var isTapBell: Bool? = nil
         var isTapWhenNotLogin: Bool? = nil
         var isLogin: Bool = false
+        var isTapHBTI: Bool? = nil
     }
     
     init() { self.initialState = State() }
@@ -63,7 +66,7 @@ final class HomeViewReactor: Reactor {
             if !currentState.isLogin {
                 return .concat([
                     .just(.setIsTapWhenNotLogin(true)),
-                    .just(.setIsTapWhenNotLogin(false))
+                    .just(.setIsTapWhenNotLogin(nil))
                 ])
             }
             
@@ -74,6 +77,13 @@ final class HomeViewReactor: Reactor {
             
         case .settingIsLogin(let isLogin):
             return .just(.setIsLogin(isLogin))
+            
+        case .didTapHBTIButton:
+            print("tap")
+            return .concat([
+                .just(.setIsTapHBTI(true)),
+                .just(.setIsTapHBTI(false))
+                ])
         }
     }
     
@@ -109,6 +119,9 @@ final class HomeViewReactor: Reactor {
             
         case .setIsLogin(let isLogin):
             state.isLogin = isLogin
+            
+        case .setIsTapHBTI(let isTap):
+            state.isTapHBTI = isTap
         }
         return state
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
@@ -79,7 +79,13 @@ final class HomeViewReactor: Reactor {
             return .just(.setIsLogin(isLogin))
             
         case .didTapHBTIButton:
-            print("tap")
+            if !currentState.isLogin {
+                return .concat([
+                    .just(.setIsTapWhenNotLogin(true)),
+                    .just(.setIsTapWhenNotLogin(nil))
+                ])
+            }
+            
             return .concat([
                 .just(.setIsTapHBTI(true)),
                 .just(.setIsTapHBTI(false))

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/View/HomeTopCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/View/HomeTopCell.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 import Then
 import Kingfisher
+import RxSwift
 
 class HomeTopCell: UICollectionViewCell {
     
@@ -17,12 +18,14 @@ class HomeTopCell: UICollectionViewCell {
     
     // MARK: - Properies
     
+    var disposeBag = DisposeBag()
+    
     private lazy var newsImageView = UIImageView().then {
         $0.layer.masksToBounds = true
         $0.layer.cornerRadius = 12
     }
     
-    private lazy var hbtiButton = UIButton().then {
+    lazy var hbtiButton = UIButton().then {
         $0.setTitle("# 향bti 검사하기", for: .normal)
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.font = .customFont(.pretendard, 14)
@@ -33,6 +36,7 @@ class HomeTopCell: UICollectionViewCell {
     private lazy var banerView = UIView().then {
         $0.backgroundColor =  #colorLiteral(red: 0.9607843137, green: 0.9450980392, blue: 0.9529411765, alpha: 1)
     }
+    
     private lazy var banerLabel = UILabel().then {
         $0.setLabelUI("", font: .pretendard_medium, size: 14, color: .banerLabelColor)
     }
@@ -50,9 +54,7 @@ extension HomeTopCell {
     func configureUI() {
         banerView.addSubview(banerLabel)
         
-        newsImageView.addSubview(hbtiButton)
-        
-        [newsImageView, banerView] .forEach { addSubview($0) }
+        [newsImageView, hbtiButton, banerView] .forEach { addSubview($0) }
         
         newsImageView.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(20)
@@ -60,8 +62,8 @@ extension HomeTopCell {
         }
         
         hbtiButton.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(15)
-            make.bottom.equalToSuperview().inset(26)
+            make.horizontalEdges.equalTo(newsImageView.snp.horizontalEdges).inset(16)
+            make.bottom.equalTo(newsImageView.snp.bottom).inset(26)
             make.height.equalTo(47)
         }
         


### PR DESCRIPTION
# 📌 이슈번호
- #223

# 📌 구현/추가 사항
- 홈 화면에서 향BTI 버튼이 눌리지 않던 문제를 해결했습니다. 그에 따라 로그아웃 상태에서 버튼을 눌렀을 때 로그인 팝업창이 뜨도록 변경했습니다.
- 향BTI 1차에서 범용적으로 쓰일 수 있는 네비바를 새로 정의했습니다. 해당 네비바의 Back 버튼을 탭하면 이전 VC가 아닌 향BTI 홈으로 이동하고, 스택에 쌓여있는 VC들을 pop합니다. 향료 선택 등, 설문결과 화면 이후의 모든 VC에서 해당 네비바함수를 사용하면 될 것 같습니다.
- 향BTI 설문 결과 로딩 화면에서 "OOO님에게 딱 맞는 \n향료를 추천하는 중입니다." 문구가 잠깐 보였다가 닉네임이 제대로 적용되는 버그를 수정했습니다. 결과를 먼저 로드하고 그 후에 닉네임 정보를 가져왔던 것 때문에 발생했던 문제여서 라벨업데이트를 분리하여 진행하도록 변경했습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/3ef63a96-27ba-416a-b367-5a94b5596c74


