### PR TITLE
[UI] 향수 매칭 결과 화면 컴포넌트

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		C9EBE6F42C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBE6F32C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift */; };
 		C9EBE6F62C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBE6F52C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift */; };
 		C9EBE6F92C8DCBF8007AB66B /* HBTIPerfumeResultSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBE6F82C8DCBF8007AB66B /* HBTIPerfumeResultSection.swift */; };
+		C9EBE6FB2C8DD664007AB66B /* HBTIPerfumeResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBE6FA2C8DD664007AB66B /* HBTIPerfumeResultCell.swift */; };
 		CA0027C52B2C5E7D001DEAE3 /* TutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */; };
 		CA0027C72B2C60F8001DEAE3 /* TutorialContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */; };
 		CA0160962AB0B11100D5839D /* SecondDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0160952AB0B11100D5839D /* SecondDetail.swift */; };
@@ -499,6 +500,7 @@
 		C9EBE6F32C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIPerfumeResultViewController.swift; sourceTree = "<group>"; };
 		C9EBE6F52C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIPerfumeResultReactor.swift; sourceTree = "<group>"; };
 		C9EBE6F82C8DCBF8007AB66B /* HBTIPerfumeResultSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIPerfumeResultSection.swift; sourceTree = "<group>"; };
+		C9EBE6FA2C8DD664007AB66B /* HBTIPerfumeResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIPerfumeResultCell.swift; sourceTree = "<group>"; };
 		CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialViewController.swift; sourceTree = "<group>"; };
 		CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialContentViewController.swift; sourceTree = "<group>"; };
 		CA0160952AB0B11100D5839D /* SecondDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondDetail.swift; sourceTree = "<group>"; };
@@ -1912,6 +1914,7 @@
 		C9EBE6EF2C8DA9A7007AB66B /* View */ = {
 			isa = PBXGroup;
 			children = (
+				C9EBE6FA2C8DD664007AB66B /* HBTIPerfumeResultCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -3017,6 +3020,7 @@
 				CA6C48632B2C2FFF00F1BE7F /* TotalPerfumeAPI.swift in Sources */,
 				2C4CDC4829C770D900676163 /* BrandSearchSection.swift in Sources */,
 				CA219C4A2AA1C635003FB215 /* LikeHeaderView.swift in Sources */,
+				C9EBE6FB2C8DD664007AB66B /* HBTIPerfumeResultCell.swift in Sources */,
 				CA69F39B29DEB2D0004958BB /* CALayer++Extenstions.swift in Sources */,
 				2CA7F69A29D2FBE70022E7FD /* TotalPerfumeReactor.swift in Sources */,
 				C96B99D22BB022B6005F4E31 /* MagazineTagCell.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		C9DEC1E82C72DF34001A2E93 /* loading.gif in Resources */ = {isa = PBXBuildFile; fileRef = C9DEC1E72C72DF34001A2E93 /* loading.gif */; };
 		C9EBE6F42C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBE6F32C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift */; };
 		C9EBE6F62C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBE6F52C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift */; };
+		C9EBE6F92C8DCBF8007AB66B /* HBTIPerfumeResultSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBE6F82C8DCBF8007AB66B /* HBTIPerfumeResultSection.swift */; };
 		CA0027C52B2C5E7D001DEAE3 /* TutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */; };
 		CA0027C72B2C60F8001DEAE3 /* TutorialContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */; };
 		CA0160962AB0B11100D5839D /* SecondDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0160952AB0B11100D5839D /* SecondDetail.swift */; };
@@ -497,6 +498,7 @@
 		C9DEC1E72C72DF34001A2E93 /* loading.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = loading.gif; sourceTree = "<group>"; };
 		C9EBE6F32C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIPerfumeResultViewController.swift; sourceTree = "<group>"; };
 		C9EBE6F52C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIPerfumeResultReactor.swift; sourceTree = "<group>"; };
+		C9EBE6F82C8DCBF8007AB66B /* HBTIPerfumeResultSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIPerfumeResultSection.swift; sourceTree = "<group>"; };
 		CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialViewController.swift; sourceTree = "<group>"; };
 		CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialContentViewController.swift; sourceTree = "<group>"; };
 		CA0160952AB0B11100D5839D /* SecondDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondDetail.swift; sourceTree = "<group>"; };
@@ -1902,6 +1904,7 @@
 		C9EBE6EE2C8DA99D007AB66B /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				C9EBE6F82C8DCBF8007AB66B /* HBTIPerfumeResultSection.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -3126,6 +3129,7 @@
 				2C04248529A4D859009CF0FE /* CommentListReactor.swift in Sources */,
 				2C4041D629AD1211009247E7 /* SearchListTableViewCell.swift in Sources */,
 				C96CD7452BA88010005C9856 /* MagazineDetailViewController.swift in Sources */,
+				C9EBE6F92C8DCBF8007AB66B /* HBTIPerfumeResultSection.swift in Sources */,
 				2C04249429A50DB4009CF0FE /* CommentDetailReactor.swift in Sources */,
 				CABED5512B3186E40030874F /* BrandDetailService.swift in Sources */,
 				2C04246E29A3E112009CF0FE /* DetailViewReactor.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -173,6 +173,8 @@
 		C9D2300D2C6AE106008ACB9B /* HBTISurveyResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */; };
 		C9D2300F2C6AE63C008ACB9B /* HBTISurveyResultSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300E2C6AE63C008ACB9B /* HBTISurveyResultSection.swift */; };
 		C9DEC1E82C72DF34001A2E93 /* loading.gif in Resources */ = {isa = PBXBuildFile; fileRef = C9DEC1E72C72DF34001A2E93 /* loading.gif */; };
+		C9EBE6F42C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBE6F32C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift */; };
+		C9EBE6F62C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBE6F52C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift */; };
 		CA0027C52B2C5E7D001DEAE3 /* TutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */; };
 		CA0027C72B2C60F8001DEAE3 /* TutorialContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */; };
 		CA0160962AB0B11100D5839D /* SecondDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0160952AB0B11100D5839D /* SecondDetail.swift */; };
@@ -493,6 +495,8 @@
 		C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTISurveyResultCell.swift; sourceTree = "<group>"; };
 		C9D2300E2C6AE63C008ACB9B /* HBTISurveyResultSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTISurveyResultSection.swift; sourceTree = "<group>"; };
 		C9DEC1E72C72DF34001A2E93 /* loading.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = loading.gif; sourceTree = "<group>"; };
+		C9EBE6F32C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIPerfumeResultViewController.swift; sourceTree = "<group>"; };
+		C9EBE6F52C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIPerfumeResultReactor.swift; sourceTree = "<group>"; };
 		CA0027C42B2C5E7D001DEAE3 /* TutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialViewController.swift; sourceTree = "<group>"; };
 		CA0027C62B2C60F8001DEAE3 /* TutorialContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialContentViewController.swift; sourceTree = "<group>"; };
 		CA0160952AB0B11100D5839D /* SecondDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondDetail.swift; sourceTree = "<group>"; };
@@ -1773,10 +1777,11 @@
 		C96F76032C3FB34800D44773 /* HBTI */ = {
 			isa = PBXGroup;
 			children = (
-				C93CA20D2C69E6A900AFD9E8 /* HBTISurveyResult */,
 				C96F760D2C40065600D44773 /* HBTI */,
 				C93BFA6E2C4295C200A5D9D2 /* HBTISurvey */,
+				C93CA20D2C69E6A900AFD9E8 /* HBTISurveyResult */,
 				C91980DF2C6D93EF00A7E91F /* HBTIPerfumeSurvey */,
+				C9EBE6ED2C8DA978007AB66B /* HBTIPerfumeResult */,
 			);
 			path = HBTI;
 			sourceTree = "<group>";
@@ -1881,6 +1886,47 @@
 				C99E7B682BA96DE200F359BC /* MagazineDetailItem.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		C9EBE6ED2C8DA978007AB66B /* HBTIPerfumeResult */ = {
+			isa = PBXGroup;
+			children = (
+				C9EBE6EE2C8DA99D007AB66B /* Model */,
+				C9EBE6EF2C8DA9A7007AB66B /* View */,
+				C9EBE6F12C8DA9B3007AB66B /* Reactor */,
+				C9EBE6F22C8DA9BB007AB66B /* ViewController */,
+			);
+			path = HBTIPerfumeResult;
+			sourceTree = "<group>";
+		};
+		C9EBE6EE2C8DA99D007AB66B /* Model */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		C9EBE6EF2C8DA9A7007AB66B /* View */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		C9EBE6F12C8DA9B3007AB66B /* Reactor */ = {
+			isa = PBXGroup;
+			children = (
+				C9EBE6F52C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift */,
+			);
+			path = Reactor;
+			sourceTree = "<group>";
+		};
+		C9EBE6F22C8DA9BB007AB66B /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				C9EBE6F32C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift */,
+			);
+			path = ViewController;
 			sourceTree = "<group>";
 		};
 		CA0027C22B2C5E52001DEAE3 /* Tutorial */ = {
@@ -2894,6 +2940,7 @@
 				2C464E5029CDB26400A07658 /* MyPageSeparatorLineView.swift in Sources */,
 				CA22389F2AAF515F00452A31 /* CommunityDetailReactor.swift in Sources */,
 				2C464E4E29CDB1C300A07658 /* UserInfo.swift in Sources */,
+				C9EBE6F62C8DAC72007AB66B /* HBTIPerfumeResultReactor.swift in Sources */,
 				C96CD74D2BA8803D005C9856 /* MagazineModel.swift in Sources */,
 				C96CD73D2BA88010005C9856 /* MagazineMainCell.swift in Sources */,
 				CA219C462A9F0985003FB215 /* LikePerfume.swift in Sources */,
@@ -3023,6 +3070,7 @@
 				CA943AD92AEF971800A5B717 /* DetailCommentService.swift in Sources */,
 				CACAD39329C9E418001D28E1 /* LoginStartViewController.swift in Sources */,
 				CAF5335E2BA046F700A7B8B2 /* MyLogComment.swift in Sources */,
+				C9EBE6F42C8DAA4E007AB66B /* HBTIPerfumeResultViewController.swift in Sources */,
 				2CA155B82A05368000D7B0C0 /* MyProfileReactor.swift in Sources */,
 				CA69039A2A3023A000EAD59A /* AppRequestInterCeptor.swift in Sources */,
 				2C1BD6A9298FAA370059A43D /* CommentCell.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIButton++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIButton++Extenstions.swift
@@ -144,4 +144,11 @@ extension UIButton {
         self.titleLabel?.font = .customFont(.pretendard, 20)
         self.setTitle("변경", for: .normal)
     }
+    
+    func setHBTIPriorityButton(title: String) {
+        self.setTitleColor(.init(hexCode: "9C9C9C"), for: .normal)
+        self.setTitleColor(.black, for: .selected)
+        self.titleLabel?.font = .customFont(.pretendard, 12)
+        self.setTitle(title, for: .normal)
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIColor++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIColor++Extenstions.swift
@@ -66,6 +66,26 @@ extension UIColor {
 }
 
 extension UIColor {
+    // hex값으로 초기화
+    convenience init(hexCode: String, alpha: CGFloat = 1.0) {
+        var hexFormatted: String = hexCode.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).uppercased()
+        
+        if hexFormatted.hasPrefix("#") {
+            hexFormatted = String(hexFormatted.dropFirst())
+        }
+        
+        assert(hexFormatted.count == 6, "Invalid hex code used.")
+        
+        var rgbValue: UInt64 = 0
+        Scanner(string: hexFormatted).scanHexInt64(&rgbValue)
+        
+        self.init(red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+                  green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+                  blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
+                  alpha: alpha)
+    }
+    
+    // 랜덤색상
     static var random: UIColor {
         UIColor(red: .random(in: 0...1), green: .random(in: 0...1), blue: .random(in: 0...1), alpha: 1.0)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -291,12 +291,20 @@ extension UIViewController {
         self.navigationController?.pushViewController(hbtiSurveyResultVC, animated: true)
     }
         
-    /// HBTINoteVC로 push
+    /// HBTIPerfumeSurveyVC로 push
     func presentHBTIPerfumeSurveyViewController() {
         let hbtiPerfumeSurveyVC = HBTIPerfumeSurveyViewController()
         hbtiPerfumeSurveyVC.reactor = HBTIPerfumeSurveyReactor()
         hbtiPerfumeSurveyVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(hbtiPerfumeSurveyVC, animated: true)
+    }
+    
+    /// HBTIPerfumeResultVC로 push
+    func presentHBTIPerfumeResultViewController() {
+        let hbtiPerfumeResultVC = HBTIPerfumeResultViewController()
+        hbtiPerfumeResultVC.reactor = HBTIPerfumeResultReactor()
+        hbtiPerfumeResultVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(hbtiPerfumeResultVC, animated: true)
     }
     
     // MARK: Configure NavigationBar

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
@@ -73,3 +73,14 @@ struct HBTINoteAnswer: Hashable {
     let category: String
     let notes: [String]
 }
+
+struct HBTIPerfumeResultResponse: Hashable {
+    let perfumeList: [HBTIPerfume]
+}
+
+struct HBTIPerfume: Hashable {
+    let id: Int
+    let nameKR: String
+    let nameEN: String
+    let price: Int
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -69,7 +69,7 @@ final class HBTIViewController: UIViewController, View {
             .filter { $0 }
             .map { _ in }
             .asDriver(onErrorRecover: { _ in return .empty() })
-            .drive(onNext: presentHBTIPerfumeSurveyViewController)
+            .drive(onNext: presentHBTIPerfumeResultViewController)
             .disposed(by: disposeBag)
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Model/HBTIPerfumeResultSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Model/HBTIPerfumeResultSection.swift
@@ -1,0 +1,16 @@
+//
+//  HBTIPerfumeResultSection.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 9/8/24.
+//
+
+import Foundation
+
+enum HBTIPerfumeResultSection: Hashable {
+    case perfume
+}
+
+enum HBTIPerfumeResultItem: Hashable {
+    case perfume(HBTIPerfume)
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
@@ -1,0 +1,46 @@
+//
+//  HBTIPerfumeResultReactor.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 9/8/24.
+//
+
+import ReactorKit
+import RxSwift
+
+final class HBTIPerfumeResultReactor: Reactor {
+    
+    enum Action {
+        
+    }
+    
+    enum Mutation {
+        
+    }
+    
+    struct State {
+        
+    }
+    
+    var initialState: State
+    
+    init() {
+        self.initialState = State()
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+            
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var state = state
+        
+        switch mutation {
+            
+        }
+        
+        return state
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/View/HBTIPerfumeResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/View/HBTIPerfumeResultCell.swift
@@ -92,6 +92,7 @@ class HBTIPerfumeResultCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super .init(frame: frame)
         
+        setUI()
         setAddView()
         setConstraints()
         
@@ -101,14 +102,6 @@ class HBTIPerfumeResultCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func layoutSubviews() {
-        
-        contentView.layer.borderWidth = 1
-        contentView.layer.cornerRadius = 5
-        contentView.layer.masksToBounds = true
-        
-    }
-    
     override func prepareForReuse() {
         super.prepareForReuse()
         disposeBag = DisposeBag()
@@ -116,6 +109,12 @@ class HBTIPerfumeResultCell: UICollectionViewCell {
     
     
     //MARK: - SetUp
+    private func setUI() {
+        layer.borderWidth = 1
+        layer.cornerRadius = 5
+        layer.masksToBounds = true
+    }
+    
     private func setAddView() {
         
         addSubview(shadowView)
@@ -158,22 +157,23 @@ class HBTIPerfumeResultCell: UICollectionViewCell {
         perpumeImageView.snp.makeConstraints { make in
             make.top.equalTo(topView.snp.bottom).offset(32)
             make.centerX.equalToSuperview()
-            make.height.width.equalTo(250)
+            make.height.width.equalTo(120)
         }
         
         nameStackView.snp.makeConstraints { make in
             make.trailing.leading.equalToSuperview().inset(24)
-            make.top.equalTo(perpumeImageView.snp.bottom).offset(8)
+            make.top.equalTo(perpumeImageView.snp.bottom).offset(46)
         }
         
         priceTextLabel.snp.makeConstraints { make in
-            make.top.equalTo(nameStackView.snp.bottom).offset(36)
+            make.top.equalTo(nameStackView.snp.bottom).offset(28)
             make.leading.equalToSuperview().inset(24)
         }
         
         priceLabel.snp.makeConstraints { make in
-            make.top.equalTo(nameStackView.snp.bottom).offset(36)
+            make.top.equalTo(nameStackView.snp.bottom).offset(28)
             make.trailing.equalToSuperview().inset(24)
+            make.bottom.equalToSuperview().inset(40)
         }
     }
     
@@ -182,8 +182,8 @@ class HBTIPerfumeResultCell: UICollectionViewCell {
         korNameLabel.text = perfume.nameKR
         engNameLabel.text = perfume.nameEN
         priceLabel.text = perfume.price.numberFormatterToWon()
-//        perpumeImageView.kf.setImage(with: URL(string: item.perfumeImageUrl))
+        //        perpumeImageView.kf.setImage(with: URL(string: item.perfumeImageUrl))
         perpumeImageView.backgroundColor = .random
     }
-
+    
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/View/HBTIPerfumeResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/View/HBTIPerfumeResultCell.swift
@@ -1,0 +1,189 @@
+//
+//  HBTIPerfumeResultCell.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 9/8/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+import RxSwift
+
+class HBTIPerfumeResultCell: UICollectionViewCell {
+    
+    // MARK: - UIComponents
+    static let identifier = "LikeCardCell"
+    
+    private let topView = UIView().then {
+        $0.backgroundColor = .black
+    }
+    let xButton = UIButton().then {
+        $0.setImage(UIImage(named: "x"), for: .normal)
+    }
+    
+    private let brandNameLabel = UILabel().then {
+        $0.setLabelUI("",
+                      font: .pretendard_medium,
+                      size: 14,
+                      color: .white)
+    }
+    
+    private let perpumeImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.clipsToBounds = true
+    }
+    
+    private let layout = UICollectionViewFlowLayout().then {
+        $0.itemSize = CGSize(width: 50, height: 18)
+        $0.minimumLineSpacing = 4
+        $0.scrollDirection = .horizontal
+    }
+    
+    private let nameStackView = UIStackView().then {
+        $0.distribution = .fillProportionally
+        $0.setStackViewUI(spacing: 8)
+    }
+    private let korNameLabel = UILabel().then {
+        $0.setLabelUI("",
+                      font: .pretendard, size: 14, color: .black)
+    }
+    
+    private let engNameLabel = UILabel().then {
+        $0.sizeToFit()
+        
+        $0.setLabelUI("",
+                      font: .pretendard,
+                      size: 12,
+                      color: .black)
+    }
+    
+    private let priceTextLabel = UILabel().then {
+        $0.setLabelUI("Price",
+                      font: .pretendard,
+                      size: 14,
+                      color: .black)
+    }
+    
+    private let priceLabel = UILabel().then {
+        $0.setLabelUI("",
+                      font: .pretendard,
+                      size: 14,
+                      color: .black)
+    }
+    
+    private let shadowView = UIView().then {
+        
+        $0.backgroundColor = .white
+        $0.layer.borderWidth = 1
+        $0.layer.cornerRadius = 5
+        $0.layer.masksToBounds = true
+        $0.layer.shadowOpacity = 0.2
+        $0.layer.shadowOffset = CGSize(width: 4, height: 4)
+        $0.layer.shadowRadius = 1
+        $0.layer.masksToBounds = false
+    }
+    
+    var disposeBag = DisposeBag()
+    
+    //MARK: - LifeCycle
+
+    override init(frame: CGRect) {
+        super .init(frame: frame)
+        
+        setAddView()
+        setConstraints()
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        
+        contentView.layer.borderWidth = 1
+        contentView.layer.cornerRadius = 5
+        contentView.layer.masksToBounds = true
+        
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+    }
+    
+    
+    //MARK: - SetUp
+    private func setAddView() {
+        
+        addSubview(shadowView)
+        
+        [xButton,
+         brandNameLabel].forEach { topView.addSubview($0) }
+        
+        [
+         korNameLabel,
+         engNameLabel].forEach { nameStackView.addArrangedSubview($0) }
+        
+        [topView,
+         perpumeImageView,
+         nameStackView,
+         priceTextLabel,
+         priceLabel].forEach { contentView.addSubview($0) }
+    }
+    
+    private func setConstraints() {
+        
+        shadowView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        topView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.height.equalTo(40)
+        }
+        
+        xButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(10)
+            make.centerY.equalToSuperview()
+            make.width.height.equalTo(30)
+        }
+        
+        brandNameLabel.snp.makeConstraints { make in
+            make.centerY.centerX.equalToSuperview()
+        }
+        
+        perpumeImageView.snp.makeConstraints { make in
+            make.top.equalTo(topView.snp.bottom).offset(32)
+            make.centerX.equalToSuperview()
+            make.height.width.equalTo(250)
+        }
+        
+        nameStackView.snp.makeConstraints { make in
+            make.trailing.leading.equalToSuperview().inset(24)
+            make.top.equalTo(perpumeImageView.snp.bottom).offset(8)
+        }
+        
+        priceTextLabel.snp.makeConstraints { make in
+            make.top.equalTo(nameStackView.snp.bottom).offset(36)
+            make.leading.equalToSuperview().inset(24)
+        }
+        
+        priceLabel.snp.makeConstraints { make in
+            make.top.equalTo(nameStackView.snp.bottom).offset(36)
+            make.trailing.equalToSuperview().inset(24)
+        }
+    }
+    
+    func configureCell(perfume: HBTIPerfume) {
+        brandNameLabel.text = "브랜드"
+        korNameLabel.text = perfume.nameKR
+        engNameLabel.text = perfume.nameEN
+        priceLabel.text = perfume.price.numberFormatterToWon()
+//        perpumeImageView.kf.setImage(with: URL(string: item.perfumeImageUrl))
+        perpumeImageView.backgroundColor = .random
+    }
+
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -112,14 +112,10 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         let layout = UICollectionViewCompositionalLayout {
             (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
             
-            let availableLayoutWidth = layoutEnvironment.container.effectiveContentSize.width
-            let centerImageWidth = availableLayoutWidth * 0.78
-            let centerImageHeight = centerImageWidth / 280 * 354
-            
-            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(354))
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.78), heightDimension: .absolute(centerImageHeight))
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.78), heightDimension: .estimated(354))
             let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
             
             let section = NSCollectionLayoutSection(group: group)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -18,9 +18,19 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
 
     // MARK: - UI Components
     
-    private var titleLabel = UILabel().then {
+    private let titleLabel = UILabel().then {
         $0.setLabelUI("", font: .pretendard_bold, size: 20, color: .black)
         $0.setTextWithLineHeight(text: "고객님에게 어울릴 향수는", lineHeight: 27)
+    }
+    
+    private let priceButton = UIButton().then {
+        $0.setHBTIPriorityButton(title: "가격대 우선")
+        $0.isSelected = true
+    }
+    
+    private let noteButton = UIButton().then {
+        $0.setHBTIPriorityButton(title: "향료 우선")
+        $0.isSelected = false
     }
     
     // MARK: - Properties
@@ -57,7 +67,9 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
     // MARK: Add Views
     private func setAddView() {
         [
-            titleLabel
+            titleLabel,
+            priceButton,
+            noteButton
         ].forEach { view.addSubview($0) }
     }
     
@@ -66,6 +78,18 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         titleLabel.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top).inset(20)
             make.horizontalEdges.equalToSuperview().inset(16)
+        }
+        
+        priceButton.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(56)
+            make.height.equalTo(12)
+        }
+        
+        noteButton.snp.makeConstraints { make in
+            make.top.equalTo(priceButton.snp.top)
+            make.leading.equalTo(priceButton.snp.trailing).offset(7)
+            make.trailing.equalToSuperview().inset(5)
+            make.height.equalTo(12)
         }
     }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -33,6 +33,11 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         $0.isSelected = false
     }
     
+//    private lazy var recommendedPerfumeCollectionView = UICollectionView(
+//        frame: .zero,
+//        collectionViewLayout: <#T##UICollectionViewLayout#>
+//    )
+    
     // MARK: - Properties
     
     var disposeBag = DisposeBag()
@@ -91,6 +96,31 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
             make.trailing.equalToSuperview().inset(5)
             make.height.equalTo(12)
         }
+    }
+    
+    // MARK: Create Layout
+    private func createLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout {
+            (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+            
+            let availableLayoutWidth = layoutEnvironment.container.effectiveContentSize.width
+            let centerImageWidth = availableLayoutWidth * 0.78
+            let centerImageHeight = centerImageWidth / 280 * 354
+            
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.92), heightDimension: .absolute(centerImageHeight))
+            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+            
+            let section = NSCollectionLayoutSection(group: group)
+            section.orthogonalScrollingBehavior = .groupPagingCentered
+            section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+            section.interGroupSpacing = 16
+            
+            return section
+        }
+        return layout
     }
 
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -38,6 +38,14 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
                     forCellWithReuseIdentifier: HBTIPerfumeResultCell.identifier)
     }
     
+    private let nextButton = UIButton().then {
+        $0.setTitle("다음", for: .normal)
+        $0.titleLabel?.font = .customFont(.pretendard, 15)
+        $0.setTitleColor(.white, for: .normal)
+        $0.layer.cornerRadius = 5
+        $0.backgroundColor = .black
+    }
+    
     // MARK: - Properties
     
     var dataSource: UICollectionViewDiffableDataSource<HBTIPerfumeResultSection, HBTIPerfumeResultItem>?
@@ -78,7 +86,8 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
             titleLabel,
             priceButton,
             noteButton,
-            perfumeCollectionView
+            perfumeCollectionView,
+            nextButton
         ].forEach { view.addSubview($0) }
     }
     
@@ -104,6 +113,12 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         perfumeCollectionView.snp.makeConstraints { make in
             make.top.equalTo(priceButton.snp.bottom).offset(22)
             make.horizontalEdges.bottom.equalToSuperview()
+        }
+        
+        nextButton.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(16)
+            make.bottom.equalToSuperview().inset(40)
+            make.height.equalTo(52)
         }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -1,0 +1,64 @@
+//
+//  HBTIPerfumeResultViewController.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 9/8/24.
+//
+
+import UIKit
+
+import SnapKit
+import ReactorKit
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+final class HBTIPerfumeResultViewController: UIViewController, View {
+
+    // MARK: - UI Components
+
+    
+    // MARK: - Properties
+    
+    var disposeBag = DisposeBag()
+    
+    // MARK: - LifeCycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+        setAddView()
+        setConstraints()
+    }
+    
+    func bind(reactor: HBTIPerfumeResultReactor) {
+        
+        // MARK: Action
+        
+        
+        // MARK: State
+        
+    }
+    
+    // MARK: - Functions
+    
+    // MARK: Set UI
+    private func setUI() {
+        view.backgroundColor = .white
+        setBackItemNaviBar("향수 추천")
+    }
+    
+    // MARK: Add Views
+    private func setAddView() {
+        [
+        ].forEach { view.addSubview($0) }
+    }
+    
+    // MARK: Set Constraints
+    private func setConstraints() {
+        
+    }
+
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -17,7 +17,11 @@ import Then
 final class HBTIPerfumeResultViewController: UIViewController, View {
 
     // MARK: - UI Components
-
+    
+    private var titleLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard_bold, size: 20, color: .black)
+        $0.setTextWithLineHeight(text: "고객님에게 어울릴 향수는", lineHeight: 27)
+    }
     
     // MARK: - Properties
     
@@ -53,12 +57,16 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
     // MARK: Add Views
     private func setAddView() {
         [
+            titleLabel
         ].forEach { view.addSubview($0) }
     }
     
     // MARK: Set Constraints
     private func setConstraints() {
-        
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).inset(20)
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
     }
 
 }


### PR DESCRIPTION
# 📌 이슈번호
- #232

# 📌 구현/추가 사항
- 향수 매칭결과 화면의 UI 컴포넌트 작업을 완료했습니다. 
- 컬렉션뷰의 Cell은 기존의 LikeCardCell을 차용해서 디자인에 맞게 약간의 변화만 주었으니, 참고바랍니다.

# 📷 미리보기
<img src="https://github.com/user-attachments/assets/ad233e9b-808e-40bc-91ce-4e01887fd71a" width="400"/>

