### PR TITLE
[New Feature] 가격대 및 향료 선택화면 상호작용

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
@@ -66,7 +66,7 @@ struct HBTIPerfumeServeyResponse: Hashable {
 struct HBTINoteQuestion: Hashable {
     let content: String
     let isMultipleChoice: Bool
-    let answer: [HBTIAnswer]
+    let answer: [HBTINoteAnswer]
 }
 
 struct HBTINoteAnswer: Hashable {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -69,7 +69,7 @@ final class HBTIViewController: UIViewController, View {
             .filter { $0 }
             .map { _ in }
             .asDriver(onErrorRecover: { _ in return .empty() })
-            .drive(onNext: presentHBTIPerfumeResultViewController)
+            .drive(onNext: presentHBTIPerfumeSurveyViewController)
             .disposed(by: disposeBag)
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -77,7 +77,7 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
     // MARK: Set UI
     private func setUI() {
         view.backgroundColor = .white
-        setBackItemNaviBar("향수 추천")
+        setBackToHBTIVCNaviBar("향수 추천")
     }
     
     // MARK: Add Views

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Model/HBTIPerfumeSurveySection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Model/HBTIPerfumeSurveySection.swift
@@ -8,8 +8,7 @@
 import Foundation
 
 enum HBTIPerfumeSurveySection: Hashable {
-    case price
-    case note
+    case survey
 }
 
 enum HBTIPerfumeSurveyItem: Hashable {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -10,15 +10,17 @@ import RxSwift
 final class HBTIPerfumeSurveyReactor: Reactor {
     
     enum Action {
-        case didTapAnswerButton(String)
+        case didTapPriceButton(String)
     }
     
     enum Mutation {
         case setSelectedPrice(String)
+        case setIsEnabledNextButton
     }
     
     struct State {
         var selectedPrice: String? = nil
+        var isEnabledNextButton: Bool = false
     }
     
     var initialState: State
@@ -29,8 +31,11 @@ final class HBTIPerfumeSurveyReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .didTapAnswerButton(let price):
-            return .just(.setSelectedPrice(price))
+        case .didTapPriceButton(let price):
+            return .concat([
+                .just(.setSelectedPrice(price)),
+                .just(.setIsEnabledNextButton)
+            ])
         }
     }
     
@@ -40,6 +45,9 @@ final class HBTIPerfumeSurveyReactor: Reactor {
         switch mutation {
         case .setSelectedPrice(let price):
             state.selectedPrice = state.selectedPrice == price ? nil : price
+            
+        case .setIsEnabledNextButton:
+            state.isEnabledNextButton = state.selectedPrice != nil
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -11,12 +11,15 @@ final class HBTIPerfumeSurveyReactor: Reactor {
     
     enum Action {
         case didTapPriceButton(String)
+        case isSelectedNoteItem(IndexPath)
+        case isDeselectedNoteItem(IndexPath)
         case didTapNextButton
         case didChangePage(Int)
     }
     
     enum Mutation {
         case setSelectedPrice(String)
+        case setSelectedNoteList(String, selcted: Bool)
         case setIsEnabledNextButton
         case setNextPage(Int)
         case setCurrentPage(Int)
@@ -33,6 +36,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
             HBTINoteAnswer(category: "시험7", notes: ["노트7-1", "노트7-2"])
         ]
         var selectedPrice: String? = nil
+        var selectedNoteList: [String] = []
         var isEnabledNextButton: Bool = false
         var currentPage: Int = 0
     }
@@ -50,6 +54,14 @@ final class HBTIPerfumeSurveyReactor: Reactor {
                 .just(.setSelectedPrice(price)),
                 .just(.setIsEnabledNextButton)
             ])
+            
+        case .isSelectedNoteItem(let indexPath):
+            let note = findNote(of: currentState.noteList, from: indexPath)
+            return .just(.setSelectedNoteList(note, selcted: true))
+            
+        case .isDeselectedNoteItem(let indexPath):
+            let note = findNote(of: currentState.noteList, from: indexPath)
+            return .just(.setSelectedNoteList(note, selcted: false))
             
         case .didChangePage(let page):
             return .concat([
@@ -69,6 +81,14 @@ final class HBTIPerfumeSurveyReactor: Reactor {
         case .setSelectedPrice(let price):
             state.selectedPrice = state.selectedPrice == price ? nil : price
             
+        case .setSelectedNoteList(let note, selcted: let selected):
+            if selected {
+                state.selectedNoteList.append(note)
+            } else {
+                let noteIndex = state.selectedNoteList.firstIndex(of: note)!
+                state.selectedNoteList.remove(at: noteIndex)
+            }
+            
         case .setIsEnabledNextButton:
             if state.currentPage == 0 {
                 state.isEnabledNextButton = state.selectedPrice != nil
@@ -86,5 +106,11 @@ final class HBTIPerfumeSurveyReactor: Reactor {
         }
         
         return state
+    }
+}
+
+extension HBTIPerfumeSurveyReactor {
+    func findNote(of noteList: [HBTINoteAnswer], from indexPath: IndexPath) -> String {
+        return noteList[indexPath.section].notes[indexPath.row]
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -26,6 +26,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
         case setIsEnabledNextButton
         case setNextPage(Int)
         case setCurrentPage(Int)
+        case setIsPushNextVC(Bool)
     }
     
     struct State {
@@ -42,6 +43,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
         var selectedNoteList: [(String, IndexPath)] = []
         var isEnabledNextButton: Bool = false
         var currentPage: Int = 0
+        var isPushNextVC = false
     }
     
     var initialState: State
@@ -88,6 +90,9 @@ final class HBTIPerfumeSurveyReactor: Reactor {
             return .just(.clearSelectedNotes)
             
         case .didTapNextButton:
+            if currentState.currentPage == 1 {
+                return .just(.setIsPushNextVC(true))
+            }
             return .just(.setNextPage(currentState.currentPage + 1))
         }
     }
@@ -125,6 +130,9 @@ final class HBTIPerfumeSurveyReactor: Reactor {
             
         case .setCurrentPage(let row):
             state.currentPage = row
+            
+        case .setIsPushNextVC(let isPush):
+            state.isPushNextVC = isPush
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -10,15 +10,15 @@ import RxSwift
 final class HBTIPerfumeSurveyReactor: Reactor {
     
     enum Action {
-        
+        case didTapAnswerButton(String)
     }
     
     enum Mutation {
-        
+        case setSelectedPrice(String)
     }
     
     struct State {
-        
+        var selectedPrice: String? = nil
     }
     
     var initialState: State
@@ -29,7 +29,8 @@ final class HBTIPerfumeSurveyReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-            
+        case .didTapAnswerButton(let price):
+            return .just(.setSelectedPrice(price))
         }
     }
     
@@ -37,7 +38,8 @@ final class HBTIPerfumeSurveyReactor: Reactor {
         var state = state
         
         switch mutation {
-            
+        case .setSelectedPrice(let price):
+            state.selectedPrice = state.selectedPrice == price ? nil : price
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -13,6 +13,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
         case didTapPriceButton(String)
         case isSelectedNoteItem(IndexPath)
         case isDeselectedNoteItem(IndexPath)
+        case didTapCancelButton(String)
         case didTapNextButton
         case didChangePage(Int)
     }
@@ -74,6 +75,12 @@ final class HBTIPerfumeSurveyReactor: Reactor {
                 .just(.setCurrentPage(page)),
                 .just(.setIsEnabledNextButton)
             ])
+            
+        case .didTapCancelButton(let noteName):
+            let noteList = currentState.selectedNoteList
+            guard let index = noteList.firstIndex(where: { $0.0 == noteName }) else { return .empty() }
+            
+            return .just(.setSelectedNoteList(noteList[index], selcted: false))
             
         case .didTapNextButton:
             return .just(.setNextPage(currentState.currentPage + 1))

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -19,7 +19,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
     
     enum Mutation {
         case setSelectedPrice(String)
-        case setSelectedNoteList(String, selcted: Bool)
+        case setSelectedNoteList((String, IndexPath), selcted: Bool)
         case setIsEnabledNextButton
         case setNextPage(Int)
         case setCurrentPage(Int)
@@ -36,7 +36,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
             HBTINoteAnswer(category: "시험7", notes: ["노트7-1", "노트7-2"])
         ]
         var selectedPrice: String? = nil
-        var selectedNoteList: [String] = []
+        var selectedNoteList: [(String, IndexPath)] = []
         var isEnabledNextButton: Bool = false
         var currentPage: Int = 0
     }
@@ -56,16 +56,16 @@ final class HBTIPerfumeSurveyReactor: Reactor {
             ])
             
         case .isSelectedNoteItem(let indexPath):
-            let note = findNote(of: currentState.noteList, from: indexPath)
+            let note = findNoteName(from: currentState.noteList, by: indexPath)
             return .concat([
-                .just(.setSelectedNoteList(note, selcted: true)),
+                .just(.setSelectedNoteList((note, indexPath), selcted: true)),
                 .just(.setIsEnabledNextButton)
             ])
             
         case .isDeselectedNoteItem(let indexPath):
-            let note = findNote(of: currentState.noteList, from: indexPath)
+            let note = findNoteName(from: currentState.noteList, by: indexPath)
             return .concat([
-                .just(.setSelectedNoteList(note, selcted: false)),
+                .just(.setSelectedNoteList((note, indexPath), selcted: false)),
                 .just(.setIsEnabledNextButton)
             ])
             
@@ -91,9 +91,10 @@ final class HBTIPerfumeSurveyReactor: Reactor {
             if selected {
                 state.selectedNoteList.append(note)
             } else {
-                let noteIndex = state.selectedNoteList.firstIndex(of: note)!
+                let noteIndex = state.selectedNoteList.map { $0.0 }.firstIndex(of: note.0)!
                 state.selectedNoteList.remove(at: noteIndex)
             }
+            print(state.selectedNoteList)
             
         case .setIsEnabledNextButton:
             if state.currentPage == 0 {
@@ -117,7 +118,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
 }
 
 extension HBTIPerfumeSurveyReactor {
-    func findNote(of noteList: [HBTINoteAnswer], from indexPath: IndexPath) -> String {
+    func findNoteName(from noteList: [HBTINoteAnswer], by indexPath: IndexPath) -> String {
         return noteList[indexPath.section].notes[indexPath.row]
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -11,16 +11,21 @@ final class HBTIPerfumeSurveyReactor: Reactor {
     
     enum Action {
         case didTapPriceButton(String)
+        case didTapNextButton
+        case didChangePage(Int)
     }
     
     enum Mutation {
         case setSelectedPrice(String)
         case setIsEnabledNextButton
+        case setNextPage(Int)
+        case setCurrentPage(Int)
     }
     
     struct State {
         var selectedPrice: String? = nil
         var isEnabledNextButton: Bool = false
+        var currentPage: Int = 0
     }
     
     var initialState: State
@@ -36,6 +41,15 @@ final class HBTIPerfumeSurveyReactor: Reactor {
                 .just(.setSelectedPrice(price)),
                 .just(.setIsEnabledNextButton)
             ])
+            
+        case .didChangePage(let page):
+            return .concat([
+                .just(.setCurrentPage(page)),
+                .just(.setIsEnabledNextButton)
+            ])
+            
+        case .didTapNextButton:
+            return .just(.setNextPage(currentState.currentPage + 1))
         }
     }
     
@@ -47,7 +61,19 @@ final class HBTIPerfumeSurveyReactor: Reactor {
             state.selectedPrice = state.selectedPrice == price ? nil : price
             
         case .setIsEnabledNextButton:
-            state.isEnabledNextButton = state.selectedPrice != nil
+            if state.currentPage == 0 {
+                state.isEnabledNextButton = state.selectedPrice != nil
+            } else {
+                // TODO: 향료 state에 따라 업데이트
+                state.isEnabledNextButton = false
+            }
+            
+        case .setNextPage(let page):
+            guard page < 2 else { break }
+            state.currentPage = page
+            
+        case .setCurrentPage(let row):
+            state.currentPage = row
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -57,11 +57,17 @@ final class HBTIPerfumeSurveyReactor: Reactor {
             
         case .isSelectedNoteItem(let indexPath):
             let note = findNote(of: currentState.noteList, from: indexPath)
-            return .just(.setSelectedNoteList(note, selcted: true))
+            return .concat([
+                .just(.setSelectedNoteList(note, selcted: true)),
+                .just(.setIsEnabledNextButton)
+            ])
             
         case .isDeselectedNoteItem(let indexPath):
             let note = findNote(of: currentState.noteList, from: indexPath)
-            return .just(.setSelectedNoteList(note, selcted: false))
+            return .concat([
+                .just(.setSelectedNoteList(note, selcted: false)),
+                .just(.setIsEnabledNextButton)
+            ])
             
         case .didChangePage(let page):
             return .concat([
@@ -92,8 +98,9 @@ final class HBTIPerfumeSurveyReactor: Reactor {
         case .setIsEnabledNextButton:
             if state.currentPage == 0 {
                 state.isEnabledNextButton = state.selectedPrice != nil
+            } else if state.currentPage == 1 {
+                state.isEnabledNextButton = state.selectedPrice != nil && state.selectedNoteList.count > 0
             } else {
-                // TODO: 향료 state에 따라 업데이트
                 state.isEnabledNextButton = false
             }
             

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -23,6 +23,15 @@ final class HBTIPerfumeSurveyReactor: Reactor {
     }
     
     struct State {
+        var noteList: [HBTINoteAnswer] = [
+            HBTINoteAnswer(category: "시험1", notes: ["노트1-1", "노트1-2"]),
+            HBTINoteAnswer(category: "시험2", notes: ["노트2-1", "노트2-2"]),
+            HBTINoteAnswer(category: "시험3", notes: ["노트3-1", "노트3-2"]),
+            HBTINoteAnswer(category: "시험4", notes: ["노트4-1", "노트4-2"]),
+            HBTINoteAnswer(category: "시험5", notes: ["노트5-1", "노트5-2"]),
+            HBTINoteAnswer(category: "시험6", notes: ["노트6-1", "노트6-2"]),
+            HBTINoteAnswer(category: "시험7", notes: ["노트7-1", "노트7-2"])
+        ]
         var selectedPrice: String? = nil
         var isEnabledNextButton: Bool = false
         var currentPage: Int = 0

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -14,6 +14,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
         case isSelectedNoteItem(IndexPath)
         case isDeselectedNoteItem(IndexPath)
         case didTapCancelButton(String)
+        case didTapClearButton
         case didTapNextButton
         case didChangePage(Int)
     }
@@ -21,6 +22,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
     enum Mutation {
         case setSelectedPrice(String)
         case setSelectedNoteList((String, IndexPath), selcted: Bool)
+        case clearSelectedNotes
         case setIsEnabledNextButton
         case setNextPage(Int)
         case setCurrentPage(Int)
@@ -82,6 +84,9 @@ final class HBTIPerfumeSurveyReactor: Reactor {
             
             return .just(.setSelectedNoteList(noteList[index], selcted: false))
             
+        case .didTapClearButton:
+            return .just(.clearSelectedNotes)
+            
         case .didTapNextButton:
             return .just(.setNextPage(currentState.currentPage + 1))
         }
@@ -101,7 +106,9 @@ final class HBTIPerfumeSurveyReactor: Reactor {
                 let noteIndex = state.selectedNoteList.map { $0.0 }.firstIndex(of: note.0)!
                 state.selectedNoteList.remove(at: noteIndex)
             }
-            print(state.selectedNoteList)
+            
+        case .clearSelectedNotes:
+            state.selectedNoteList = []
             
         case .setIsEnabledNextButton:
             if state.currentPage == 0 {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTINoteQuestionCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTINoteQuestionCell.swift
@@ -147,25 +147,7 @@ class HBTINoteQuestionCell: UICollectionViewCell {
             
         })
         
-        var initialSnapshot = NSDiffableDataSourceSnapshot<HBTINoteQuestionSection, HBTINoteQuestionItem>()
-        
-        let sections = [
-            HBTINoteAnswer(category: "시험1", notes: ["노트1-1", "노트1-2"]),
-            HBTINoteAnswer(category: "시험2", notes: ["노트2-1", "노트2-2"]),
-            HBTINoteAnswer(category: "시험3", notes: ["노트3-1", "노트3-2"]),
-            HBTINoteAnswer(category: "시험4", notes: ["노트4-1", "노트4-2"]),
-            HBTINoteAnswer(category: "시험5", notes: ["노트5-1", "노트5-2"]),
-            HBTINoteAnswer(category: "시험6", notes: ["노트6-1", "노트6-2"]),
-            HBTINoteAnswer(category: "시험7", notes: ["노트7-1", "노트7-2"])
-        ]
-        
-        for data in sections {
-            let section = HBTINoteQuestionSection(category: data.category)
-            initialSnapshot.appendSections([section])
-            
-            let items = data.notes.map { HBTINoteQuestionItem(note: $0)}
-            initialSnapshot.appendItems(items, toSection: section)
-        }
+        let initialSnapshot = NSDiffableDataSourceSnapshot<HBTINoteQuestionSection, HBTINoteQuestionItem>()
         
         dataSource?.apply(initialSnapshot, animatingDifferences: false)
         
@@ -189,6 +171,22 @@ class HBTINoteQuestionCell: UICollectionViewCell {
     
     func configureCell(question: HBTINoteQuestion) {
         selectLabel.text = question.content
+    }
+    
+    func updateSnapshot(withNoteAnswers notes: [HBTINoteAnswer]) {
+        guard let dataSource = self.dataSource else { return }
+        
+        var snapshot = dataSource.snapshot()
+        
+        for data in notes {
+            let section = HBTINoteQuestionSection(category: data.category)
+            snapshot.appendSections([section])
+            
+            let items = data.notes.map { HBTINoteQuestionItem(note: $0)}
+            snapshot.appendItems(items, toSection: section)
+        }
+        
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
     
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTINoteQuestionCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTINoteQuestionCell.swift
@@ -80,7 +80,7 @@ class HBTINoteQuestionCell: UICollectionViewCell {
     private func setConstraints() {
         selectedNoteView.snp.makeConstraints { make in
             make.top.horizontalEdges.equalToSuperview()
-            make.height.equalTo(78)
+            make.height.equalTo(0)
         }
         
         selectLabel.snp.makeConstraints { make in
@@ -168,7 +168,9 @@ class HBTINoteQuestionCell: UICollectionViewCell {
             }
         }
     }
-    
+}
+
+extension HBTINoteQuestionCell {
     func configureCell(question: HBTINoteQuestion) {
         selectLabel.text = question.content
     }
@@ -189,4 +191,9 @@ class HBTINoteQuestionCell: UICollectionViewCell {
         dataSource.apply(snapshot, animatingDifferences: false)
     }
     
+    func updateHeight(condition: Bool) {
+        selectedNoteView.snp.updateConstraints { make in
+            make.height.equalTo(condition ? 0 : 78)
+        }
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTINoteQuestionCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTINoteQuestionCell.swift
@@ -159,7 +159,11 @@ class HBTINoteQuestionCell: UICollectionViewCell {
                     ofKind: SupplementaryViewKind.header,
                     withReuseIdentifier: HBTINoteCategoryHeaderView.identifier,
                     for: indexPath) as! HBTINoteCategoryHeaderView
-                headerView.configureHeader("헤더")
+                
+                if let currentSnapshot = self.dataSource?.snapshot() {
+                    let sectionTitle = currentSnapshot.sectionIdentifiers[indexPath.section].category
+                    headerView.configureHeader(sectionTitle)
+                }
                 
                 return headerView
                 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTINoteQuestionCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTINoteQuestionCell.swift
@@ -186,6 +186,7 @@ extension HBTINoteQuestionCell {
         
         for data in notes {
             let section = HBTINoteQuestionSection(category: data.category)
+            guard !snapshot.sectionIdentifiers.contains(section) else { return }
             snapshot.appendSections([section])
             
             let items = data.notes.map { HBTINoteQuestionItem(note: $0)}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTISelectedNoteCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTISelectedNoteCell.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import SnapKit
 import Then
+import RxSwift
 
 final class HBTISelectedNoteCell: UICollectionViewCell {
     static let identifier = "HBTIselectedNoteCell"
@@ -21,6 +22,10 @@ final class HBTISelectedNoteCell: UICollectionViewCell {
     let xButton = UIButton().then {
         $0.setImage(UIImage(named: "noteXButton"), for: .normal)
     }
+    
+    // MARK: - Properties
+    
+    var disposeBag = DisposeBag()
     
     // MARK: - Initialization
     override init(frame: CGRect) {
@@ -65,5 +70,9 @@ final class HBTISelectedNoteCell: UICollectionViewCell {
     
     func configureCell(_ noteName: String) {
         tagLabel.text = noteName
+    }
+    
+    func bindButtonAction() -> Observable<Void> {
+        return xButton.rx.tap.asObservable()
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTISelectedNoteView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTISelectedNoteView.swift
@@ -117,13 +117,22 @@ final class HBTISelectedNoteView: UIView {
                 
                 return cell
             }
-            
         })
         
         var initialSnapshot = NSDiffableDataSourceSnapshot<HBTISelectedNoteSection, HBTISelectedNoteItem>()
         initialSnapshot.appendSections([.selected])
-        initialSnapshot.appendItems([.note("선택된 향료1"), .note("선택된 향료2"), .note("선택된 향료3"), .note("선택된 향료4")])
         
         dataSource?.apply(initialSnapshot, animatingDifferences: false)
+    }
+    
+    func updateSnapshot(with notes: [String]) {
+        guard let dataSource = self.dataSource else { return }
+        
+        var snapshot = dataSource.snapshot()
+        
+        snapshot.deleteItems(snapshot.itemIdentifiers(inSection: .selected))
+        snapshot.appendItems(notes.map { .note($0) }, toSection: .selected)
+        
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTISelectedNoteView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/View/HBTISelectedNoteView.swift
@@ -135,4 +135,9 @@ final class HBTISelectedNoteView: UIView {
         
         dataSource.apply(snapshot, animatingDifferences: false)
     }
+    
+    func hideSelectedNoteCollectionView(isEmptySelectedNoteList: Bool) {
+        self.selectedNoteCollectionView.isHidden = isEmptySelectedNoteList
+        self.clearButton.isHidden = isEmptySelectedNoteList
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
@@ -149,6 +149,26 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
                 
                 cell.configureCell(question: question, answers: question.answers)
                 
+                for (i, view) in cell.answerStackView.subviews.enumerated() {
+                    guard i < question.answers.count else { break }
+                    
+                    let button = view as! UIButton
+                    let priceInfo = question.answers[i].content
+                    
+                    button.rx.tap
+                        .map { Reactor.Action.didTapPriceButton(priceInfo) }
+                        .bind(to: self.reactor!.action)
+                        .disposed(by: self.disposeBag)
+                    
+                    self.reactor?.state
+                        .map {
+                            guard let selectedPrice = $0.selectedPrice else { return false }
+                            return selectedPrice == priceInfo
+                        }
+                        .bind(to: button.rx.isSelected)
+                        .disposed(by: cell.disposeBag)
+                }
+                
                 return cell
                 
             case .note(let question):
@@ -166,7 +186,7 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
         initialSnapshot.appendSections([.price, .note])
         
         initialSnapshot.appendItems([
-            .price(HBTIQuestion(id: 1, content: "시험용", answers: [HBTIAnswer(id: 1, content: "시험")], isMultipleChoice: false)),
+            .price(HBTIQuestion(id: 1, content: "시험용", answers: [HBTIAnswer(id: 1, content: "가격1"), HBTIAnswer(id: 2, content: "가격2")], isMultipleChoice: false)),
             .note(HBTINoteQuestion(content: "시향 후 마음에 드는 향료를 골라주세요", isMultipleChoice: true, answer: []))
         ])
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
@@ -94,6 +94,14 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
                 }
             })
             .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isPushNextVC }
+            .filter { $0 }
+            .map { _ in }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(onNext: presentHBTIPerfumeResultViewController)
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Functions

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
@@ -235,6 +235,7 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
                     .asDriver(onErrorRecover: { _ in .empty()})
                     .drive(with: self, onNext: { owner, selectedNoteList in
                         cell.selectedNoteView.updateSnapshot(with: selectedNoteList.map { $0.0 })
+                        cell.updateHeight(condition: selectedNoteList.isEmpty)
                         owner.deselectRemovedItems(from: selectedNoteList,
                                                    in: cell.noteCategoryCollectionView)
                     })

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
@@ -254,6 +254,11 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
                     })
                     .disposed(by: cell.disposeBag)
                 
+                cell.selectedNoteView.clearButton.rx.tap
+                    .map { Reactor.Action.didTapClearButton }
+                    .bind(to: self.reactor!.action)
+                    .disposed(by: self.disposeBag)
+                
                 return cell
             }
         })

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
@@ -220,6 +220,16 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
                     })
                     .disposed(by: cell.disposeBag)
                 
+                cell.noteCategoryCollectionView.rx.itemSelected
+                    .map { Reactor.Action.isSelectedNoteItem($0) }
+                    .bind(to: self.reactor!.action)
+                    .disposed(by: self.disposeBag)
+                
+                cell.noteCategoryCollectionView.rx.itemDeselected
+                    .map { Reactor.Action.isDeselectedNoteItem($0) }
+                    .bind(to: self.reactor!.action)
+                    .disposed(by: self.disposeBag)
+                
                 return cell
             }
         })

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
@@ -70,6 +70,14 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
         
         // MARK: State
         
+        reactor.state
+            .map { $0.isEnabledNextButton }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, isEnabled in
+                owner.nextButton.isEnabled = isEnabled
+                owner.nextButton.backgroundColor = isEnabled ? .black : UIColor.customColor(.gray3)
+            })
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Functions

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
@@ -75,6 +75,14 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
         // MARK: State
         
         reactor.state
+            .map { ($0.selectedPrice, $0.selectedNoteList) }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { (owner, option) in
+                owner.updateProgressbar(option, owner)
+            })
+            .disposed(by: disposeBag)
+        
+        reactor.state
             .map { $0.isEnabledNextButton }
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, isEnabled in
@@ -296,5 +304,19 @@ extension HBTIPerfumeSurveyViewController {
                 collectionView.deselectItem(at: indexPath, animated: false)
             }
         }
+    }
+    
+    func updateProgressbar(_ option: (String?, [(String, IndexPath)]), _ owner: HBTIPerfumeSurveyViewController) {
+        let (price, noteList) = option
+        var progress: Float = 0
+        
+        if price != nil && !noteList.isEmpty {
+            progress = 1
+        } else if price != nil || !noteList.isEmpty {
+            progress = 0.5
+        } else {
+            progress = 0
+        }
+        owner.progressBar.setProgress(progress, animated: true)
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
@@ -204,12 +204,21 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
                 
                 return cell
                 
-            case .note(let question):
+            case .note(let note):
                 let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: HBTINoteQuestionCell.identifier,
                     for: indexPath) as! HBTINoteQuestionCell
                 
-                cell.configureCell(question: question)
+                cell.configureCell(question: note)
+                
+                self.reactor?.state
+                    .map { $0.noteList }
+                    .distinctUntilChanged()
+                    .asDriver(onErrorRecover: { _ in .empty() })
+                    .drive(with: self, onNext: { owner, noteList in
+                        cell.updateSnapshot(withNoteAnswers: noteList)
+                    })
+                    .disposed(by: cell.disposeBag)
                 
                 return cell
             }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
@@ -230,6 +230,14 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
                     .bind(to: self.reactor!.action)
                     .disposed(by: self.disposeBag)
                 
+                self.reactor?.state
+                    .map { $0.selectedNoteList }
+                    .asDriver(onErrorRecover: { _ in .empty()})
+                    .drive(with: self, onNext: { owenr, noteList in
+                        cell.selectedNoteView.updateSnapshot(with: noteList.map { $0.0 })
+                    })
+                    .disposed(by: cell.disposeBag)
+                
                 return cell
             }
         })

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/ViewController/HBTIPerfumeSurveyViewController.swift
@@ -216,7 +216,7 @@ final class HBTIPerfumeSurveyViewController: UIViewController, View {
         })
         
         var initialSnapshot = NSDiffableDataSourceSnapshot<HBTIPerfumeSurveySection, HBTIPerfumeSurveyItem>()
-        initialSnapshot.appendSections([.price])
+        initialSnapshot.appendSections([.survey])
         
         initialSnapshot.appendItems([
             .price(HBTIQuestion(id: 1, content: "시험용", answers: [HBTIAnswer(id: 1, content: "가격1"), HBTIAnswer(id: 2, content: "가격2")], isMultipleChoice: false)),


### PR DESCRIPTION
# 📌 이슈번호
- #234 

# 📌 구현/추가 사항
- 향BTI 2차 명세에 해당하는 향수 매칭 서비스의 설문 화면에서 상호작용에 대한 기능을 구현했습니다.
- 향BTI 홈에서 버튼을 통해 이동하기 전에 사용자가 향료 매칭 서비스를 구매했는지에 대한 여부에 따라서 팝업창을 띄워야하기 때문에 이 부분은 3차 진행하면서 함께 구현하겠습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/228ddbd2-904a-4a9c-92c7-a799927f36f8

