### PR TITLE
[New Feature] 향수 매칭 결과 화면 상호작용

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		C91980E72C6D952600A7E91F /* HBTIPerfumeSurveyReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91980E62C6D952500A7E91F /* HBTIPerfumeSurveyReactor.swift */; };
 		C923018F2C7483E0002A95BE /* HBTIAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = C923018E2C7483E0002A95BE /* HBTIAddress.swift */; };
 		C92301912C7483EA002A95BE /* HBTIAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92301902C7483EA002A95BE /* HBTIAPI.swift */; };
+		C92D5C892C9C1A5D007A1CA2 /* ResultPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92D5C882C9C1A5D007A1CA2 /* ResultPriority.swift */; };
 		C93BFA6D2C428E9300A5D9D2 /* IntroViewHBTI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA6C2C428E9300A5D9D2 /* IntroViewHBTI.swift */; };
 		C93BFA762C4295FC00A5D9D2 /* HBTISurveyReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA6F2C4295FC00A5D9D2 /* HBTISurveyReactor.swift */; };
 		C93BFA782C4295FC00A5D9D2 /* HBTISurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BFA742C4295FC00A5D9D2 /* HBTISurveyViewController.swift */; };
@@ -445,6 +446,7 @@
 		C91980E62C6D952500A7E91F /* HBTIPerfumeSurveyReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIPerfumeSurveyReactor.swift; sourceTree = "<group>"; };
 		C923018E2C7483E0002A95BE /* HBTIAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIAddress.swift; sourceTree = "<group>"; };
 		C92301902C7483EA002A95BE /* HBTIAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIAPI.swift; sourceTree = "<group>"; };
+		C92D5C882C9C1A5D007A1CA2 /* ResultPriority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultPriority.swift; sourceTree = "<group>"; };
 		C93BFA6C2C428E9300A5D9D2 /* IntroViewHBTI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewHBTI.swift; sourceTree = "<group>"; };
 		C93BFA6F2C4295FC00A5D9D2 /* HBTISurveyReactor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HBTISurveyReactor.swift; sourceTree = "<group>"; };
 		C93BFA742C4295FC00A5D9D2 /* HBTISurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HBTISurveyViewController.swift; sourceTree = "<group>"; };
@@ -1907,6 +1909,7 @@
 			isa = PBXGroup;
 			children = (
 				C9EBE6F82C8DCBF8007AB66B /* HBTIPerfumeResultSection.swift */,
+				C92D5C882C9C1A5D007A1CA2 /* ResultPriority.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -3002,6 +3005,7 @@
 				CA2238902AAEFCC000452A31 /* CommunityWriteViewController.swift in Sources */,
 				CAD1EC112A7A60CF003B21FD /* EvaluationHeaderView.swift in Sources */,
 				C9819D772C3302270046FE55 /* NoItemView.swift in Sources */,
+				C92D5C892C9C1A5D007A1CA2 /* ResultPriority.swift in Sources */,
 				C984245D2C429C1300530259 /* HBTISurveyAnswerButton.swift in Sources */,
 				2CD023632A092A5200459801 /* UserYearService.swift in Sources */,
 				2C4DD36E29754B410027CE40 /* HomeCell.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -35,9 +35,14 @@ final class HBTIViewController: UIViewController, View {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setUI()
         setAddView()
         setConstraints()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        setClearWhiteBackNaviBar("향BTI", .white)
     }
     
     // MARK: - Bind
@@ -74,10 +79,6 @@ final class HBTIViewController: UIViewController, View {
     }
     
     // MARK: - Functions
-    
-    private func setUI() {
-        setClearWhiteBackNaviBar("향BTI", .white)
-    }
     
     // MARK: Add Views
     private func setAddView() {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Model/HBTIPerfumeResultSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Model/HBTIPerfumeResultSection.swift
@@ -14,3 +14,13 @@ enum HBTIPerfumeResultSection: Hashable {
 enum HBTIPerfumeResultItem: Hashable {
     case perfume(HBTIPerfume)
 }
+
+extension HBTIPerfumeResultItem {
+    var perfume: HBTIPerfume? {
+        if case .perfume(let perfume) = self {
+            return perfume
+        } else {
+            return nil
+        }
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Model/ResultPriority.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Model/ResultPriority.swift
@@ -1,0 +1,13 @@
+//
+//  ResultPriority.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 9/19/24.
+//
+
+import Foundation
+
+enum ResultPriority {
+    case price
+    case note
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
@@ -12,14 +12,17 @@ final class HBTIPerfumeResultReactor: Reactor {
     
     enum Action {
         case didTapNextButton
+        case didTapPriorityButton(ResultPriority)
     }
     
     enum Mutation {
         case setIsPushNextVC
+        case setResultPriority(ResultPriority)
     }
     
     struct State {
         var isPushNextVC: Bool = false
+        var resultPriority: ResultPriority = .price
     }
     
     var initialState: State
@@ -32,6 +35,9 @@ final class HBTIPerfumeResultReactor: Reactor {
         switch action {
         case .didTapNextButton:
             return .just(.setIsPushNextVC)
+            
+        case .didTapPriorityButton(let priority):
+            return .just(.setResultPriority(priority))
         }
     }
     
@@ -41,6 +47,9 @@ final class HBTIPerfumeResultReactor: Reactor {
         switch mutation {
         case .setIsPushNextVC:
             state.isPushNextVC = true
+            
+        case .setResultPriority(let priority):
+            state.resultPriority = priority
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
@@ -11,15 +11,15 @@ import RxSwift
 final class HBTIPerfumeResultReactor: Reactor {
     
     enum Action {
-        
+        case didTapNextButton
     }
     
     enum Mutation {
-        
+        case setIsPushNextVC
     }
     
     struct State {
-        
+        var isPushNextVC: Bool = false
     }
     
     var initialState: State
@@ -30,7 +30,8 @@ final class HBTIPerfumeResultReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-            
+        case .didTapNextButton:
+            return .just(.setIsPushNextVC)
         }
     }
     
@@ -38,7 +39,8 @@ final class HBTIPerfumeResultReactor: Reactor {
         var state = state
         
         switch mutation {
-            
+        case .setIsPushNextVC:
+            state.isPushNextVC = true
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
@@ -13,16 +13,24 @@ final class HBTIPerfumeResultReactor: Reactor {
     enum Action {
         case didTapNextButton
         case didTapPriorityButton(ResultPriority)
+        case didTapPerfumeCell(IndexPath)
     }
     
     enum Mutation {
         case setIsPushNextVC
         case setResultPriority(ResultPriority)
+        case setSelectedPerfumeID(IndexPath?)
     }
     
     struct State {
+        var perfumeList: [HBTIPerfumeResultItem] = [
+            .perfume(HBTIPerfume(id: 32, nameKR: "한국 이름1", nameEN: "English name1", price: 40000)),
+            .perfume(HBTIPerfume(id: 22, nameKR: "한국 이름2", nameEN: "English name2", price: 540000)),
+            .perfume(HBTIPerfume(id: 12, nameKR: "한국 이름3", nameEN: "English name3", price: 12000))
+        ]
         var isPushNextVC: Bool = false
         var resultPriority: ResultPriority = .price
+        var selectedPerfumeID: Int? = nil
     }
     
     var initialState: State
@@ -38,6 +46,12 @@ final class HBTIPerfumeResultReactor: Reactor {
             
         case .didTapPriorityButton(let priority):
             return .just(.setResultPriority(priority))
+            
+        case .didTapPerfumeCell(let indexPath):
+            return .concat([
+                .just(.setSelectedPerfumeID(indexPath)),
+                .just(.setSelectedPerfumeID(nil))
+            ])
         }
     }
     
@@ -50,6 +64,13 @@ final class HBTIPerfumeResultReactor: Reactor {
             
         case .setResultPriority(let priority):
             state.resultPriority = priority
+            
+        case .setSelectedPerfumeID(let indexPath):
+            guard let indexPath = indexPath else { 
+                state.selectedPerfumeID = nil
+                break
+            }
+            state.selectedPerfumeID = state.perfumeList[indexPath.row].perfume?.id
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/View/HBTIPerfumeResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/View/HBTIPerfumeResultCell.swift
@@ -14,13 +14,10 @@ import RxSwift
 class HBTIPerfumeResultCell: UICollectionViewCell {
     
     // MARK: - UIComponents
-    static let identifier = "LikeCardCell"
+    static let identifier = "HBTIPerfumeResultCell"
     
     private let topView = UIView().then {
         $0.backgroundColor = .black
-    }
-    let xButton = UIButton().then {
-        $0.setImage(UIImage(named: "x"), for: .normal)
     }
     
     private let brandNameLabel = UILabel().then {
@@ -119,8 +116,7 @@ class HBTIPerfumeResultCell: UICollectionViewCell {
         
         addSubview(shadowView)
         
-        [xButton,
-         brandNameLabel].forEach { topView.addSubview($0) }
+        [brandNameLabel].forEach { topView.addSubview($0) }
         
         [
          korNameLabel,
@@ -142,12 +138,6 @@ class HBTIPerfumeResultCell: UICollectionViewCell {
         topView.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
             make.height.equalTo(40)
-        }
-        
-        xButton.snp.makeConstraints { make in
-            make.leading.equalToSuperview().inset(10)
-            make.centerY.equalToSuperview()
-            make.width.height.equalTo(30)
         }
         
         brandNameLabel.snp.makeConstraints { make in

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -44,6 +44,7 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         $0.setTitleColor(.white, for: .normal)
         $0.layer.cornerRadius = 5
         $0.backgroundColor = .black
+        $0.isEnabled = true
     }
     
     // MARK: - Properties
@@ -67,8 +68,20 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         
         // MARK: Action
         
+        nextButton.rx.tap
+            .map { Reactor.Action.didTapNextButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         
         // MARK: State
+        
+        reactor.state
+            .map { $0.isPushNextVC }
+            .filter { $0 }
+            .map { _ in }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(onNext: popToHBTIViewController)
+            .disposed(by: disposeBag)
         
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -68,12 +68,28 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         
         // MARK: Action
         
+        priceButton.rx.tap
+            .map { Reactor.Action.didTapPriorityButton(.price) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        noteButton.rx.tap
+            .map { Reactor.Action.didTapPriorityButton(.note) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         nextButton.rx.tap
             .map { Reactor.Action.didTapNextButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
         // MARK: State
+        
+        reactor.state
+            .map { $0.resultPriority }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(onNext: togglePriority(_:))
+            .disposed(by: disposeBag)
         
         reactor.state
             .map { $0.isPushNextVC }
@@ -180,4 +196,8 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         dataSource?.apply(initialSnapshot, animatingDifferences: false)
     }
 
+    private func togglePriority(_ priority: ResultPriority) {
+        priceButton.isSelected = priority == .price
+        noteButton.isSelected = priority == .note
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -78,6 +78,11 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        perfumeCollectionView.rx.itemSelected
+            .map { Reactor.Action.didTapPerfumeCell($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         nextButton.rx.tap
             .map { Reactor.Action.didTapNextButton }
             .bind(to: reactor.action)
@@ -89,6 +94,14 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
             .map { $0.resultPriority }
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(onNext: togglePriority(_:))
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.selectedPerfumeID }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, id in
+                owner.presentDetailViewController(id)
+            })
             .disposed(by: disposeBag)
         
         reactor.state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -64,6 +64,12 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         configureDataSource()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        setNavigationBar()
+    }
+    
     func bind(reactor: HBTIPerfumeResultReactor) {
         
         // MARK: Action
@@ -119,6 +125,11 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
     // MARK: Set UI
     private func setUI() {
         view.backgroundColor = .white
+        setNavigationBar()
+    }
+    
+    private func setNavigationBar() {
+        navigationController?.navigationBar.scrollEdgeAppearance?.shadowColor = .clear
         setBackToHBTIVCNaviBar("향수 추천")
     }
     


### PR DESCRIPTION
# 📌 이슈번호
- #237 

# 📌 구현/추가 사항
- 향BTI 2차 - 향수매칭 서비스의 결과화면 상호작용을 구현했습니다.
- 조회하는 향수는 임의로 지정해두었습니다.
- 향수 상세화면에서 향BTI로 돌아왔을 때 매거진 개발때처럼 네비바가 유지되지 않아 마찬가지로 viewWillAppear를 통해 화면이 나타날 때마다 네비바를 적용하도록 구현했습니다.
- 우선순위 토글 기능은 아직 향수컬렉션뷰에 반영되지는 않고, 단순히 버튼이 배타적으로 On/Off 되도록 구현되어있고, API 작업할 때 리스트도 함께 바뀌도록 변경하겠습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/84b5023d-bfbb-4cfd-8e15-ee58cec4c19f
