### PR TITLE
[New Feature] 향BTI 2차 네트워킹

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -300,9 +300,9 @@ extension UIViewController {
     }
     
     /// HBTIPerfumeResultVC로 push
-    func presentHBTIPerfumeResultViewController() {
+    func presentHBTIPerfumeResultViewController(_ minPrice: Int, _ maxPrice: Int, _ notes: [String]) {
         let hbtiPerfumeResultVC = HBTIPerfumeResultViewController()
-        hbtiPerfumeResultVC.reactor = HBTIPerfumeResultReactor()
+        hbtiPerfumeResultVC.reactor = HBTIPerfumeResultReactor(minPrice, maxPrice, notes)
         hbtiPerfumeResultVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(hbtiPerfumeResultVC, animated: true)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
@@ -25,4 +25,12 @@ final class HBTIAPI {
             data: data,
             model: HBTISurveyResultResponse.self)
     }
+    
+    static func fetchPerfumeSurvey() -> Observable<HBTIPerfumeServeyResponse> {
+        return networking(
+            urlStr: HBTIAddress.fetchPerfumeSurvey.url,
+            method: .get,
+            data: nil,
+            model: HBTIPerfumeServeyResponse.self)
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
@@ -33,4 +33,15 @@ final class HBTIAPI {
             data: nil,
             model: HBTIPerfumeServeyResponse.self)
     }
+    
+    static func postPerfumeAnswer(params: [String: Any], isContainAll: Bool) -> Observable<HBTIPerfumeResultResponse> {
+        let data = try? JSONSerialization.data(withJSONObject: params, options: .prettyPrinted)
+        
+        return networking(
+            urlStr: HBTIAddress.postPerfumeAnswer.url,
+            method: .post,
+            data: data,
+            model: HBTIPerfumeResultResponse.self,
+            query: ["isContainAll": isContainAll])
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
@@ -10,6 +10,7 @@ import Foundation
 enum HBTIAddress {
     case fetchQuestionList
     case postAnswerList
+    case fetchPerfumeSurvey
     
     var url: String {
         switch self {
@@ -17,6 +18,8 @@ enum HBTIAddress {
             return "survey/note"
         case .postAnswerList:
             return "survey/note/respond"
+        case .fetchPerfumeSurvey:
+            return "survey/perfume"
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
@@ -11,6 +11,7 @@ enum HBTIAddress {
     case fetchQuestionList
     case postAnswerList
     case fetchPerfumeSurvey
+    case postPerfumeAnswer
     
     var url: String {
         switch self {
@@ -20,6 +21,8 @@ enum HBTIAddress {
             return "survey/note/respond"
         case .fetchPerfumeSurvey:
             return "survey/perfume"
+        case .postPerfumeAnswer:
+            return "survey/perfume/respond"
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
@@ -74,13 +74,28 @@ struct HBTINoteAnswer: Hashable, Codable {
     let notes: [String]
 }
 
-struct HBTIPerfumeResultResponse: Hashable {
+struct HBTIPerfumeResultResponse: Hashable, Codable {
     let perfumeList: [HBTIPerfume]
+    
+    enum CodingKeys: String, CodingKey {
+        case perfumeList = "recommendPerfumes"
+    }
 }
 
-struct HBTIPerfume: Hashable {
+struct HBTIPerfume: Hashable, Codable {
     let id: Int
     let nameKR: String
     let nameEN: String
+    let brand: String
     let price: Int
+    let imageURL: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "perfumeId"
+        case nameKR = "perfumeName"
+        case nameEN = "perfumeEnglishName"
+        case brand = "brandName"
+        case price
+        case imageURL = "perfumeImageUrl"
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
@@ -58,18 +58,18 @@ struct HBTISurveyResultNote: Hashable, Codable {
 }
 
 // 2차 (배송 후 향수 추천)
-struct HBTIPerfumeServeyResponse: Hashable {
+struct HBTIPerfumeServeyResponse: Hashable, Codable {
     let priceQuestion: HBTIQuestion
     let noteQuestion: HBTINoteQuestion
 }
 
-struct HBTINoteQuestion: Hashable {
+struct HBTINoteQuestion: Hashable, Codable {
     let content: String
     let isMultipleChoice: Bool
     let answer: [HBTINoteAnswer]
 }
 
-struct HBTINoteAnswer: Hashable {
+struct HBTINoteAnswer: Hashable, Codable {
     let category: String
     let notes: [String]
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
@@ -23,6 +23,9 @@ final class HBTIPerfumeResultReactor: Reactor {
     }
     
     struct State {
+        let minPrice: Int
+        let maxPrice: Int
+        let selectedNoteList: [String]
         var perfumeList: [HBTIPerfumeResultItem] = [
             .perfume(HBTIPerfume(id: 32, nameKR: "한국 이름1", nameEN: "English name1", price: 40000)),
             .perfume(HBTIPerfume(id: 22, nameKR: "한국 이름2", nameEN: "English name2", price: 540000)),
@@ -35,8 +38,8 @@ final class HBTIPerfumeResultReactor: Reactor {
     
     var initialState: State
     
-    init() {
-        self.initialState = State()
+    init(_ minPrice: Int, _ maxPrice: Int, _ notes: [String]) {
+        self.initialState = State(minPrice: minPrice, maxPrice: maxPrice, selectedNoteList: notes)
     }
     
     func mutate(action: Action) -> Observable<Mutation> {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/Reactor/HBTIPerfumeResultReactor.swift
@@ -11,12 +11,14 @@ import RxSwift
 final class HBTIPerfumeResultReactor: Reactor {
     
     enum Action {
+        case viewDidLoad
         case didTapNextButton
         case didTapPriorityButton(ResultPriority)
         case didTapPerfumeCell(IndexPath)
     }
     
     enum Mutation {
+        case setPerfumeList([HBTIPerfumeResultItem])
         case setIsPushNextVC
         case setResultPriority(ResultPriority)
         case setSelectedPerfumeID(IndexPath?)
@@ -26,11 +28,7 @@ final class HBTIPerfumeResultReactor: Reactor {
         let minPrice: Int
         let maxPrice: Int
         let selectedNoteList: [String]
-        var perfumeList: [HBTIPerfumeResultItem] = [
-            .perfume(HBTIPerfume(id: 32, nameKR: "한국 이름1", nameEN: "English name1", price: 40000)),
-            .perfume(HBTIPerfume(id: 22, nameKR: "한국 이름2", nameEN: "English name2", price: 540000)),
-            .perfume(HBTIPerfume(id: 12, nameKR: "한국 이름3", nameEN: "English name3", price: 12000))
-        ]
+        var perfumeList: [HBTIPerfumeResultItem] = []
         var isPushNextVC: Bool = false
         var resultPriority: ResultPriority = .price
         var selectedPerfumeID: Int? = nil
@@ -44,11 +42,19 @@ final class HBTIPerfumeResultReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .viewDidLoad:
+            return setPerfumeList(isContainAll: false)
+            
         case .didTapNextButton:
             return .just(.setIsPushNextVC)
             
         case .didTapPriorityButton(let priority):
-            return .just(.setResultPriority(priority))
+            let noteFirst = priority == .note
+            
+            return .concat([
+                .just(.setResultPriority(priority)),
+                setPerfumeList(isContainAll: noteFirst)
+            ])
             
         case .didTapPerfumeCell(let indexPath):
             return .concat([
@@ -62,6 +68,9 @@ final class HBTIPerfumeResultReactor: Reactor {
         var state = state
         
         switch mutation {
+        case .setPerfumeList(let item):
+            state.perfumeList = item
+            
         case .setIsPushNextVC:
             state.isPushNextVC = true
             
@@ -73,9 +82,32 @@ final class HBTIPerfumeResultReactor: Reactor {
                 state.selectedPerfumeID = nil
                 break
             }
-            state.selectedPerfumeID = state.perfumeList[indexPath.row].perfume?.id
+            state.selectedPerfumeID = state.perfumeList[indexPath.row].perfume!.id
         }
         
         return state
+    }
+}
+
+extension HBTIPerfumeResultReactor {
+    private func setPerfumeList(isContainAll: Bool) -> Observable<Mutation> {
+        let maxPrice = currentState.maxPrice
+        let minPrice = currentState.minPrice
+        let notes = currentState.selectedNoteList
+        
+        let params: [String: Any] = [
+            "maxPrice": maxPrice,
+            "minPrice": minPrice,
+            "notes": notes
+        ]
+        
+        return HBTIAPI.postPerfumeAnswer(params: params, isContainAll: isContainAll)
+            .catch { _ in .empty() }
+            .flatMap { perfumeListData -> Observable<Mutation> in
+                let perfumeList = perfumeListData.perfumeList.map { perfumeData in
+                    return HBTIPerfumeResultItem.perfume(perfumeData)
+                }
+                return .just(.setPerfumeList(perfumeList))
+            }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/View/HBTIPerfumeResultCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/View/HBTIPerfumeResultCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import SnapKit
 import Then
 import RxSwift
@@ -168,12 +169,11 @@ class HBTIPerfumeResultCell: UICollectionViewCell {
     }
     
     func configureCell(perfume: HBTIPerfume) {
-        brandNameLabel.text = "브랜드"
+        brandNameLabel.text = perfume.brand
         korNameLabel.text = perfume.nameKR
         engNameLabel.text = perfume.nameEN
         priceLabel.text = perfume.price.numberFormatterToWon()
-        //        perpumeImageView.kf.setImage(with: URL(string: item.perfumeImageUrl))
-        perpumeImageView.backgroundColor = .random
+        perpumeImageView.kf.setImage(with: URL(string: perfume.imageURL))
     }
     
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeSurvey/Reactor/HBTIPerfumeSurveyReactor.swift
@@ -33,15 +33,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
     
     struct State {
         var questionList: [HBTIPerfumeSurveyItem] = []
-        var noteList: [HBTINoteAnswer] = [
-            HBTINoteAnswer(category: "시험1", notes: ["노트1-1", "노트1-2"]),
-            HBTINoteAnswer(category: "시험2", notes: ["노트2-1", "노트2-2"]),
-            HBTINoteAnswer(category: "시험3", notes: ["노트3-1", "노트3-2"]),
-            HBTINoteAnswer(category: "시험4", notes: ["노트4-1", "노트4-2"]),
-            HBTINoteAnswer(category: "시험5", notes: ["노트5-1", "노트5-2"]),
-            HBTINoteAnswer(category: "시험6", notes: ["노트6-1", "노트6-2"]),
-            HBTINoteAnswer(category: "시험7", notes: ["노트7-1", "노트7-2"])
-        ]
+        var noteList: [HBTINoteAnswer] = []
         var selectedPrice: String? = nil
         var selectedNoteList: [(String, IndexPath)] = []
         var isEnabledNextButton: Bool = false
@@ -109,6 +101,7 @@ final class HBTIPerfumeSurveyReactor: Reactor {
         switch mutation {
         case .setQuestionList(let item):
             state.questionList = item
+            state.noteList = item[1].note!.answer
             
         case .setSelectedPrice(let price):
             state.selectedPrice = state.selectedPrice == price ? nil : price


### PR DESCRIPTION
# 📌 이슈번호
- #239

# 📌 구현/추가 사항
- 향수매칭설문 데이터를 불러오고, 선택된 답변을 서버로 보내 매칭된 향수 리스트를 불러오는 기능을 구현했습니다.
- 향료 주문 여부에 따라 홈의 '향료 입력하기'버튼을 눌렀을 때 주문 유도 팝업창이 뜨는 기능은 서버쪽에서 주문 상태에 따라 true,false를 변경하도록 업데이트가 되면 구현하겠습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/95ef8294-19d0-45ad-9a32-1cf5dd94a97c