### PR TITLE
[New Feature] 향료 카테고리 선택화면 상호작용

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -307,9 +307,9 @@ extension UIViewController {
     }
   
     /// HBTINotesCatrgoryVC로 push
-    func presentHBTINotesCategoryViewController(_ selectedQuantity: Int) {
+    func presentHBTINotesCategoryViewController(_ selectedQuantity: Int, _ isFreeSelection: Bool) {
         let hbtiNotesCategoryVC = HBTINotesCategoryViewController()
-        hbtiNotesCategoryVC.reactor = HBTINotesCategoryReactor(selectedQuantity)
+        hbtiNotesCategoryVC.reactor = HBTINotesCategoryReactor(selectedQuantity, isFreeSelection)
         hbtiNotesCategoryVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(hbtiNotesCategoryVC, animated: true)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/Reactor/HBTINotesCategoryReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/Reactor/HBTINotesCategoryReactor.swift
@@ -22,6 +22,7 @@ final class HBTINotesCategoryReactor: Reactor {
     
     struct State {
         var selectedQuantity: Int
+        var isFreeSelection: Bool
         var selectedNote: [Int] = []
         var isEnabledNextButton: Bool = false
         var isPushNextVC: Bool = false
@@ -29,8 +30,8 @@ final class HBTINotesCategoryReactor: Reactor {
     
     var initialState: State
     
-    init(_ selectedQuantity: Int) {
-        self.initialState = State(selectedQuantity: selectedQuantity)
+    init(_ selectedQuantity: Int, _ isFreeSelection: Bool) {
+        self.initialState = State(selectedQuantity: selectedQuantity, isFreeSelection: isFreeSelection)
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -45,17 +46,15 @@ final class HBTINotesCategoryReactor: Reactor {
                 selectedNote.append(id)
             }
             
+            let isEnabledNextButton = currentState.isFreeSelection ? selectedNote.count > 0 : selectedNote.count == currentState.selectedQuantity
+            
             return .concat([
                 .just(.setUpdateNoteList(selectedNote)),
-                .just(.setIsEnabledNextButton(selectedNote.count == currentState.selectedQuantity))
-            ])  
+                .just(.setIsEnabledNextButton(isEnabledNextButton))
+            ])
             
         case .didTapNextButton:
-            if currentState.isEnabledNextButton {
-                return .just(.setIsPushNextVC(true))
-            }
-            
-            return .empty()
+            return currentState.isEnabledNextButton ? .just(.setIsPushNextVC(true)) : .empty()
         }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/Reactor/HBTINotesCategoryReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/Reactor/HBTINotesCategoryReactor.swift
@@ -15,7 +15,7 @@ final class HBTINotesCategoryReactor: Reactor {
     }
     
     enum Mutation {
-        case setUpdateNoteList([Int])
+        case setSelectedNote([Int])
         case setIsEnabledNextButton(Bool)
         case setIsPushNextVC(Bool)
     }
@@ -49,12 +49,14 @@ final class HBTINotesCategoryReactor: Reactor {
             let isEnabledNextButton = currentState.isFreeSelection ? selectedNote.count > 0 : selectedNote.count == currentState.selectedQuantity
             
             return .concat([
-                .just(.setUpdateNoteList(selectedNote)),
+                .just(.setSelectedNote(selectedNote)),
                 .just(.setIsEnabledNextButton(isEnabledNextButton))
             ])
             
         case .didTapNextButton:
-            return currentState.isEnabledNextButton ? .just(.setIsPushNextVC(true)) : .empty()
+            let isEnabled = currentState.isEnabledNextButton
+            
+            return .just(.setIsPushNextVC(isEnabled))
         }
     }
     
@@ -62,7 +64,7 @@ final class HBTINotesCategoryReactor: Reactor {
         var state = state
         
         switch mutation {
-        case .setUpdateNoteList(let selectedNotes):
+        case .setSelectedNote(let selectedNotes):
             state.selectedNote = selectedNotes
             
         case .setIsEnabledNextButton(let isEnabled):

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/Reactor/HBTINotesCategoryReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/Reactor/HBTINotesCategoryReactor.swift
@@ -11,16 +11,20 @@ import ReactorKit
 final class HBTINotesCategoryReactor: Reactor {
     enum Action {
         case didTapNote(Int)
-//        case didTapNextButton
+        case didTapNextButton
     }
     
     enum Mutation {
         case setUpdateNoteList([Int])
+        case setIsEnabledNextButton(Bool)
+        case setIsPushNextVC(Bool)
     }
     
     struct State {
         var selectedQuantity: Int
         var selectedNote: [Int] = []
+        var isEnabledNextButton: Bool = false
+        var isPushNextVC: Bool = false
     }
     
     var initialState: State
@@ -41,7 +45,17 @@ final class HBTINotesCategoryReactor: Reactor {
                 selectedNote.append(id)
             }
             
-            return .just(.setUpdateNoteList(selectedNote))
+            return .concat([
+                .just(.setUpdateNoteList(selectedNote)),
+                .just(.setIsEnabledNextButton(selectedNote.count == currentState.selectedQuantity))
+            ])  
+            
+        case .didTapNextButton:
+            if currentState.isEnabledNextButton {
+                return .just(.setIsPushNextVC(true))
+            }
+            
+            return .empty()
         }
     }
     
@@ -51,6 +65,12 @@ final class HBTINotesCategoryReactor: Reactor {
         switch mutation {
         case .setUpdateNoteList(let selectedNotes):
             state.selectedNote = selectedNotes
+            
+        case .setIsEnabledNextButton(let isEnabled):
+            state.isEnabledNextButton = isEnabled
+            
+        case .setIsPushNextVC(let isPush):
+            state.isPushNextVC = isPush
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/Reactor/HBTINotesCategoryReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/Reactor/HBTINotesCategoryReactor.swift
@@ -10,15 +10,17 @@ import ReactorKit
 
 final class HBTINotesCategoryReactor: Reactor {
     enum Action {
-        
+        case didTapNote(Int)
+//        case didTapNextButton
     }
     
     enum Mutation {
-
+        case setUpdateNoteList([Int])
     }
     
     struct State {
         var selectedQuantity: Int
+        var selectedNote: [Int] = []
     }
     
     var initialState: State
@@ -28,10 +30,29 @@ final class HBTINotesCategoryReactor: Reactor {
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
-        
+        switch action {
+        case .didTapNote(let id):
+            var selectedNote = currentState.selectedNote
+            
+            if let index = selectedNote.firstIndex(of: id) {
+                selectedNote.remove(at: index)
+            }
+            else if selectedNote.count < currentState.selectedQuantity {
+                selectedNote.append(id)
+            }
+            
+            return .just(.setUpdateNoteList(selectedNote))
+        }
     }
     
     func reduce(state: State, mutation: Mutation) -> State {
+        var state = state
         
+        switch mutation {
+        case .setUpdateNoteList(let selectedNotes):
+            state.selectedNote = selectedNotes
+        }
+        
+        return state
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/View/HBTINotesCategoryButton.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/View/HBTINotesCategoryButton.swift
@@ -128,13 +128,10 @@ final class HBTINotesCategoryButton: UIButton {
         }
     }
     
-    // TODO: 파라미터 id 출력은 확인용이므로 최종적으론 삭제
-    func configureButton(with category: HBTINotesCategoryData, _ id: [Int]) {
+    func configureButton(with category: HBTINotesCategoryData) {
         customImageView.image = UIImage(named: category.image)?.resize(targetSize: CGSize(width: 68, height: 68))
         customTitleLabel.text = category.title
         descriptionLabel.text = category.description
-        
-        print("===================선택된 id값들: \(id)===========")
     }
     
     func setOverlayVisible(_ isVisible: Bool) {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/View/HBTINotesCategoryButton.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/View/HBTINotesCategoryButton.swift
@@ -32,6 +32,30 @@ final class HBTINotesCategoryButton: UIButton {
         $0.numberOfLines = 3
     }
     
+    private let overlayView = UIView().then {
+        $0.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+        $0.layer.cornerRadius = 34
+    }
+    
+    private let overlayBigCircleView = UIView().then {
+        $0.backgroundColor = .clear
+        $0.layer.cornerRadius = 38
+        $0.layer.borderWidth = 2
+        $0.layer.borderColor = UIColor.black.cgColor
+    }
+    
+    private let overlaySmallCircleView = UIView().then {
+        $0.backgroundColor = .clear
+        $0.layer.cornerRadius = 34
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = UIColor.black.cgColor
+    }
+    
+    private let selectionIndexLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard_bold, size: 14, color: .white)
+        $0.textAlignment = .center
+    }
+    
     // MARK: - Init
         
     override init(frame: CGRect) {
@@ -58,7 +82,11 @@ final class HBTINotesCategoryButton: UIButton {
         [
          customImageView,
          customTitleLabel,
-         descriptionLabel
+         descriptionLabel,
+         overlayView,
+         overlayBigCircleView,
+         overlaySmallCircleView,
+         selectionIndexLabel
         ].forEach(addSubview)
     }
     
@@ -66,6 +94,7 @@ final class HBTINotesCategoryButton: UIButton {
     
     private func setConstraints() {
         customImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(4)
             $0.centerX.equalToSuperview()
             $0.size.equalTo(68)
         }
@@ -79,11 +108,45 @@ final class HBTINotesCategoryButton: UIButton {
             $0.top.equalTo(customTitleLabel.snp.bottom).offset(4)
             $0.centerX.equalToSuperview()
         }
+        
+        overlayView.snp.makeConstraints {
+            $0.edges.equalTo(customImageView)
+        }
+        
+        overlayBigCircleView.snp.makeConstraints {
+            $0.center.equalTo(customImageView)
+            $0.size.equalTo(76)
+        }
+        
+        overlaySmallCircleView.snp.makeConstraints {
+            $0.center.equalTo(customImageView)
+            $0.size.equalTo(68)
+        }
+        
+        selectionIndexLabel.snp.makeConstraints {
+            $0.center.equalTo(overlayView)
+        }
     }
     
-    func configureButton(with category: HBTINotesCategoryData) {
+    // TODO: 파라미터 id 출력은 확인용이므로 최종적으론 삭제
+    func configureButton(with category: HBTINotesCategoryData, _ id: [Int]) {
         customImageView.image = UIImage(named: category.image)?.resize(targetSize: CGSize(width: 68, height: 68))
         customTitleLabel.text = category.title
         descriptionLabel.text = category.description
+        
+        print("===================선택된 id값들: \(id)===========")
+    }
+    
+    func setOverlayVisible(_ isVisible: Bool) {
+        overlayView.isHidden = !isVisible
+        overlayBigCircleView.isHidden = !isVisible
+        overlaySmallCircleView.isHidden = !isVisible
+    }
+    
+    func setSelectionIndexLabel(_ index: Int?, _ isVisible: Bool) {
+        if isVisible, let index = index {
+            selectionIndexLabel.text = "\(index + 1)"
+            selectionIndexLabel.isHidden = false
+        }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/View/HBTINotesCategoryCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/View/HBTINotesCategoryCell.swift
@@ -66,7 +66,7 @@ final class HBTINotesCategoryCell: UICollectionViewCell, ReuseIdentifying {
             let isSelected = selectedNote.contains(note.id)
             let selectionIndex = selectedNote.firstIndex(of: note.id)
             
-            button.configureButton(with: note, selectedNote)
+            button.configureButton(with: note)
             button.setOverlayVisible(isSelected)
             button.setSelectionIndexLabel(selectionIndex, isSelected)
             

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/View/HBTINotesCategoryCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/View/HBTINotesCategoryCell.swift
@@ -18,6 +18,7 @@ final class HBTINotesCategoryCell: UICollectionViewCell, ReuseIdentifying {
         $0.spacing = 16
         $0.distribution = .fillEqually
         $0.alignment = .fill
+        $0.isUserInteractionEnabled = false
     }
     
     // MARK: - Init
@@ -57,13 +58,22 @@ final class HBTINotesCategoryCell: UICollectionViewCell, ReuseIdentifying {
     
     // MARK: - Configuration
     
-    func configureCell(with note: [HBTINotesCategoryData]) {
-        note.forEach {
+    func configureCell(with notes: [HBTINotesCategoryData], selectedNote: [Int]) {
+        categoryStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
+        notes.forEach { note in
             let button = HBTINotesCategoryButton()
-            button.configureButton(with: $0)
+            let isSelected = selectedNote.contains(note.id)
+            let selectionIndex = selectedNote.firstIndex(of: note.id)
+            
+            button.configureButton(with: note, selectedNote)
+            button.setOverlayVisible(isSelected)
+            button.setSelectionIndexLabel(selectionIndex, isSelected)
+            
             button.snp.makeConstraints {
                 $0.height.equalTo(134)
             }
+            
             categoryStackView.addArrangedSubview(button)
         }
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesResult/ViewController/HBTINotesResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesResult/ViewController/HBTINotesResultViewController.swift
@@ -66,6 +66,7 @@ final class HBTINotesResultViewController: UIViewController {
     // MARK: Set UI
     
     private func setUI() {
+        view.backgroundColor = .white
         setBackItemNaviBar("향BTI")
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIQuantitySelect/Reactor/HBTIQuantitySelectReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIQuantitySelect/Reactor/HBTIQuantitySelectReactor.swift
@@ -46,7 +46,9 @@ final class HBTIQuantitySelectReactor: Reactor {
             ])
             
         case .didTapNextButton:
-            return currentState.isEnabledNextButton ? .just(.setIsPushNextVC(true)) : .empty()
+            let isEnabled = currentState.isEnabledNextButton
+            
+            return .just(.setIsPushNextVC(isEnabled))
         }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIQuantitySelect/Reactor/HBTIQuantitySelectReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIQuantitySelect/Reactor/HBTIQuantitySelectReactor.swift
@@ -18,12 +18,14 @@ final class HBTIQuantitySelectReactor: Reactor {
         case setSeledtedIndex(Int)
         case setIsEnabledNextButton(Bool)
         case setIsPushNextVC(Bool)
+        case setIsFreeSelection(Bool)
     }
     
     struct State {
         var selectedIndex: Int? = nil
         var isEnabledNextButton: Bool = false
         var isPushNextVC: Bool = false
+        var isFreeSelection: Bool = false
     }
     
     var initialState: State
@@ -35,17 +37,16 @@ final class HBTIQuantitySelectReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .didSelectQuantity(let indexPath):
+            let isFreeSelection = (indexPath.row == 3)
+            
             return .concat([
                 .just(.setSeledtedIndex(indexPath.row)),
-                .just(.setIsEnabledNextButton(true))
+                .just(.setIsEnabledNextButton(true)),
+                .just(.setIsFreeSelection(isFreeSelection))
             ])
             
         case .didTapNextButton:
-            if currentState.selectedIndex != nil {
-                return .just(.setIsPushNextVC(true))
-            }
-            
-            return .empty()
+            return currentState.isEnabledNextButton ? .just(.setIsPushNextVC(true)) : .empty()
         }
     }
     
@@ -61,6 +62,9 @@ final class HBTIQuantitySelectReactor: Reactor {
             
         case .setIsPushNextVC(let isPush):
             state.isPushNextVC = isPush
+            
+        case .setIsFreeSelection(let isFree):
+            state.isFreeSelection = isFree
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIQuantitySelect/ViewController/HBTIQuantitySelectViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIQuantitySelect/ViewController/HBTIQuantitySelectViewController.swift
@@ -86,9 +86,10 @@ final class HBTIQuantitySelectViewController: UIViewController, View {
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, _ in
                 guard let selectedIndex = owner.reactor?.currentState.selectedIndex else { return }
+                guard let isFreeSelection = owner.reactor?.currentState.isFreeSelection else { return }
                 let selectedQuantity = NotesQuantity.quantities[selectedIndex].quantity
                 
-                owner.presentHBTINotesCategoryViewController(selectedQuantity)
+                owner.presentHBTINotesCategoryViewController(selectedQuantity, isFreeSelection)
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
# 📌 이슈번호
- #252 

# 📌 구현/추가 사항
- 향BTI 향료 카테고리 선택 화면 상호작용 작업을 완료했습니다.
- 8개 수량을 선택한 경우, 전체 향료 개수가 7개라 다음 버튼이 비활성화되어서 추후 확인 후 수정하도록 하겠습니다.
- 자유롭게 선택의 경우, 1개 이상만 선택하면 되도록 만들었습니다.
- 향료 선택 결과화면에서 나오는 시향카드들이 서버에서 정보를 받아오는 것 같아서 일단 아무런 정보도 넘겨주지 않았습니다. (presentNotesResult시에 아무 인자값도 넘겨주지 않은 상태)

# 📷 미리보기
https://github.com/user-attachments/assets/547b1dd6-d5e5-4c6b-91df-248f1e23949f