### PR TITLE
[New Feature] 주문내역 상호작용 및 네트워킹

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HMOA_iOS/HMOA_iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "17ad9c1b9344646ba7987bf9895fd5665d055e04b39c551c26234393538683d7",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+        "version" : "5.9.1"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk.git",
+      "state" : {
+        "revision" : "9f9b830dfd7ee66607c6fddcfeb1a6bc07e48714",
+        "version" : "2.22.2"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk-rx",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk-rx",
+      "state" : {
+        "revision" : "86d53e524acd1a9eb0a2c95d23e700ac9d727480",
+        "version" : "2.22.2"
+      }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "pretendardkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/wookeon/PretendardKit.git",
+      "state" : {
+        "revision" : "d8362d8ecee86c297f2784fa453037136914bc2c",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "rxalamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxAlamofire.git",
+      "state" : {
+        "revision" : "9535b58695b91fb67f56d58d6fd0c76462d7743a",
+        "version" : "6.1.2"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
+        "version" : "6.7.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIButton++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIButton++Extenstions.swift
@@ -9,6 +9,19 @@ import UIKit
 
 extension UIButton {
     
+    func grayBorderButton(title: String) -> UIButton {
+        let button = UIButton().then {
+            $0.setTitle(title, for: .normal)
+            $0.titleLabel?.font = .customFont(.pretendard_semibold, 12)
+            $0.setTitleColor(.customColor(.gray3), for: .normal)
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.customColor(.gray3).cgColor
+            $0.layer.cornerRadius = 3
+        }
+        
+        return button
+    }
+    
     func makeFloatingListButton(title: String) -> UIButton {
         var config = UIButton.Configuration.plain()
         var titleAttr = AttributedString.init(title)

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
@@ -124,7 +124,7 @@ struct HBTICategory: Codable, Hashable {
         case name = "productName"
         case imageURL = "productPhotoUrl"
         case noteCount = "notesCount"
-        case noteList
+        case noteList = "notes"
         case price
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
@@ -99,3 +99,42 @@ struct HBTIPerfume: Hashable, Codable {
         case imageURL = "perfumeImageUrl"
     }
 }
+
+// 1차 후반후, 3차
+struct HBTICategoryListInfo: Codable, Hashable {
+    let totalPrice: Int
+    let categoryList: [HBTICategory]
+    
+    enum CodingKeys: String, CodingKey {
+        case totalPrice
+        case categoryList = "noteProducts"
+    }
+}
+
+struct HBTICategory: Codable, Hashable {
+    let id: Int
+    let name: String
+    let imageURL: String
+    let noteCount: Int
+    let noteList: [HBTINote]
+    let price: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "productId"
+        case name = "productName"
+        case imageURL = "productPhotoUrl"
+        case noteCount = "notesCount"
+        case noteList
+        case price
+    }
+}
+
+struct HBTINote: Codable, Hashable {
+    let name: String
+    let content: String
+    
+    enum CodingKeys: String, CodingKey {
+        case name = "noteName"
+        case content = "noteContent"
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/MemberAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/MemberAPI.swift
@@ -198,4 +198,13 @@ final class MemberAPI {
             return .just(false)
         }
     }
+    
+    static func fetchOrderList(_ query: [String: Int]) -> Observable<OrderResponse> {
+        return networking(
+            urlStr: MemberAddress.fetchOrder.url,
+            method: .get,
+            data: nil,
+            model: OrderResponse.self,
+            query: query)
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/MemberAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/MemberAddress.swift
@@ -21,6 +21,7 @@ enum MemberAddress {
     case fetchCommunityComment
     case fetchWritedPost
     case deleteMember
+    case fetchOrder
 }
 
 extension MemberAddress {
@@ -52,6 +53,8 @@ extension MemberAddress {
             return "member/communities"
         case .deleteMember:
             return "member/delete"
+        case .fetchOrder:
+            return "member/order"
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 struct Member: Codable, Hashable {
     var age: Int
@@ -83,6 +84,13 @@ enum OrderStatus: String, Codable {
             return "배송 완료"
         case .PURCHASE_CONFIRMATION:
             return "구매 확정"
+        }
+    }
+    
+    var textColor: UIColor {
+        switch self {
+        case .SHIPPING_COMPLETE: return .customColor(.blue)
+        default: return .black
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
@@ -15,3 +15,45 @@ struct Member: Codable, Hashable {
     var provider: String
     var sex: Bool
 }
+
+struct OrderResponse: Codable {
+    let orders: [Order]
+    let isLastPage: Bool
+    
+    enum CodingKeys: String, CodingKey {
+        case orders = "data"
+        case isLastPage = "lastPage"
+    }
+}
+
+struct Order: Codable, Hashable {
+    let id: Int
+    let status: String
+    let products: OrderInfo
+    let createdAt: String
+    let courierCompany: String?
+    let trackingNumber: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "orderId"
+        case status = "orderStatus"
+        case products = "orderProducts"
+        case createdAt
+        case courierCompany
+        case trackingNumber
+    }
+}
+
+struct OrderInfo: Codable, Hashable {
+    let categoryListInfo: HBTICategoryListInfo
+    let paymentAmount: Int
+    let shippingFee: Int
+    let totalAmount: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case categoryListInfo
+        case paymentAmount
+        case shippingFee = "shippingAmount"
+        case totalAmount
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
@@ -57,3 +57,32 @@ struct OrderInfo: Codable, Hashable {
         case totalAmount
     }
 }
+
+enum OrderStatus: String, Codable {
+    case CREATED = "CREATED"
+    case PAY_FAILED = "PAY_FAILED"
+    case PAY_COMPLETE = "PAY_COMPLETE"
+    case PAY_CANCEL = "PAY_CANCEL"
+    case SHIPPING_PROGRESS = "SHIPPING_PROGRESS"
+    case SHIPPING_COMPLETE = "SHIPPING_COMPLETE"
+    case PURCHASE_CONFIRMATION = "PURCHASE_CONFIRMATION"
+    
+    var kr: String {
+        switch self {
+        case .CREATED:
+            return "주문 생성"
+        case .PAY_FAILED:
+            return "결제 실패"
+        case .PAY_COMPLETE:
+            return "주문 완료"
+        case .PAY_CANCEL:
+            return "주문 취소"
+        case .SHIPPING_PROGRESS:
+            return "배송 중"
+        case .SHIPPING_COMPLETE:
+            return "배송 완료"
+        case .PURCHASE_CONFIRMATION:
+            return "구매 확정"
+        }
+    }
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/Model/Member.swift
@@ -51,7 +51,7 @@ struct OrderInfo: Codable, Hashable {
     let totalAmount: Int
     
     enum CodingKeys: String, CodingKey {
-        case categoryListInfo
+        case categoryListInfo = "productInfo"
         case paymentAmount
         case shippingFee = "shippingAmount"
         case totalAmount

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Model/OrderLogSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Model/OrderLogSection.swift
@@ -23,4 +23,115 @@ extension OrderLogItem {
             return nil
         }
     }
+    
+    static let exampleOrder: [OrderLogItem] = [
+        .order(Order(
+            id: 1,
+            status: OrderStatus.PAY_COMPLETE.rawValue,
+            products: OrderInfo(
+                categoryListInfo: HBTICategoryListInfo(
+                    totalPrice: 40000,
+                    categoryList: [
+                        HBTICategory(
+                            id: 1,
+                            name: "시트러스",
+                            imageURL: "https://example.com/citrus.jpeg",
+                            noteCount: 3,
+                            noteList: [
+                                HBTINote(name: "라임", content: "상쾌하고 달콤한 라임 향"),
+                                HBTINote(name: "레몬", content: "시원한 레몬 향"),
+                                HBTINote(name: "오렌지", content: "진하고 상큼한 오렌지 향")
+                            ],
+                            price: 20000
+                        ),
+                        HBTICategory(
+                            id: 2,
+                            name: "플로럴",
+                            imageURL: "https://example.com/floral.jpeg",
+                            noteCount: 2,
+                            noteList: [
+                                HBTINote(name: "로즈", content: "달콤하고 은은한 장미 향"),
+                                HBTINote(name: "라벤더", content: "편안하고 깊이 있는 라벤더 향")
+                            ],
+                            price: 20000
+                        )
+                    ]
+                ),
+                paymentAmount: 40000,
+                shippingFee: 3000,
+                totalAmount: 43000
+            ),
+            createdAt: "2024/09/24",
+            courierCompany: nil,
+            trackingNumber: nil
+        )),
+        .order(Order(
+            id: 2,
+            status: OrderStatus.SHIPPING_PROGRESS.rawValue,
+            products: OrderInfo(
+                categoryListInfo: HBTICategoryListInfo(
+                    totalPrice: 30000,
+                    categoryList: [
+                        HBTICategory(
+                            id: 2,
+                            name: "우디",
+                            imageURL: "https://example.com/woody.jpeg",
+                            noteCount: 2,
+                            noteList: [
+                                HBTINote(name: "시더우드", content: "따뜻하고 깊이 있는 나무 향"),
+                                HBTINote(name: "베티버", content: "흙내음이 나는 깊고 묵직한 나무 향")
+                            ],
+                            price: 15000
+                        )
+                    ]
+                ),
+                paymentAmount: 30000,
+                shippingFee: 3000,
+                totalAmount: 33000
+            ),
+            createdAt: "2024/09/25",
+            courierCompany: "대한통운",
+            trackingNumber: "1234567890"
+        )),
+        .order(Order(
+            id: 3,
+            status: OrderStatus.SHIPPING_COMPLETE.rawValue,
+            products: OrderInfo(
+                categoryListInfo: HBTICategoryListInfo(
+                    totalPrice: 75000,
+                    categoryList: [
+                        HBTICategory(
+                            id: 5,
+                            name: "프루티",
+                            imageURL: "https://example.com/fruity.jpeg",
+                            noteCount: 3,
+                            noteList: [
+                                HBTINote(name: "복숭아", content: "달콤하고 부드러운 복숭아 향"),
+                                HBTINote(name: "블랙베리", content: "진하고 달콤한 블랙베리 향"),
+                                HBTINote(name: "자몽", content: "새콤하고 상큼한 자몽 향")
+                            ],
+                            price: 35000
+                        ),
+                        HBTICategory(
+                            id: 6,
+                            name: "그린",
+                            imageURL: "https://example.com/green.jpeg",
+                            noteCount: 2,
+                            noteList: [
+                                HBTINote(name: "바질", content: "상쾌하고 풍부한 허브 향"),
+                                HBTINote(name: "파인", content: "산뜻하고 시원한 솔잎 향")
+                            ],
+                            price: 40000
+                        )
+                    ]
+                ),
+                paymentAmount: 75000,
+                shippingFee: 3500,
+                totalAmount: 78500
+            ),
+            createdAt: "2024/09/26",
+            courierCompany: "한진택배",
+            trackingNumber: "0987654321"
+        ))
+    ]
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Model/OrderLogSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Model/OrderLogSection.swift
@@ -12,12 +12,11 @@ enum OrderLogSection: Hashable {
 }
 
 enum OrderLogItem: Hashable {
-    // TODO: String -> Networking Model로 교체
-    case order(String)
+    case order(Order)
 }
 
 extension OrderLogItem {
-    var order: String? {
+    var order: Order? {
         if case .order(let order) = self {
             return order
         } else {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
@@ -11,15 +11,15 @@ import RxSwift
 final class OrderLogReactor: Reactor {
     
     enum Action {
-        
+        case viewDidLoad
     }
     
     enum Mutation {
-        
+        case setOrderList([OrderLogItem])
     }
     
     struct State {
-        
+        var orderList: [OrderLogItem] = []
     }
     
     var initialState: State
@@ -30,7 +30,8 @@ final class OrderLogReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-            
+        case .viewDidLoad:
+            return setOrderList()
         }
     }
     
@@ -38,9 +39,24 @@ final class OrderLogReactor: Reactor {
         var state = state
         
         switch mutation {
-            
+        case .setOrderList(let order):
+            print(order)
+            state.orderList = order
         }
         
         return state
+    }
+}
+
+extension OrderLogReactor {
+    func setOrderList() -> Observable<Mutation> {
+        return MemberAPI.fetchOrderList(["cursor": 0])
+            .catch { _ in .empty() }
+            .flatMap { OrderResponseData -> Observable<Mutation> in
+                let orderItemList = OrderResponseData.orders.map { order in
+                    return OrderLogItem.order(order)
+                }
+                return .just(.setOrderList(orderItemList))
+            }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
@@ -40,7 +40,6 @@ final class OrderLogReactor: Reactor {
         
         switch mutation {
         case .setOrderList(let order):
-            print(order)
             state.orderList = order
         }
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
@@ -21,7 +21,7 @@ final class OrderLogReactor: Reactor {
     }
     
     struct State {
-        var orderList: [OrderLogItem] = []
+        var orderList: [OrderLogItem] = OrderLogItem.exampleOrder
         var nextPage: Int = 0
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
@@ -13,16 +13,25 @@ final class OrderLogReactor: Reactor {
     enum Action {
         case viewDidLoad
         case loadNextPage
+        case didTapRefundButton
+        case didTapReturnButton
+        case didTapReviewButton
     }
     
     enum Mutation {
         case setOrderList([OrderLogItem])
         case setNextPage(Int)
+        case setIsPushRefundVC(Bool)
+        case setIsPushReturnVC(Bool)
+        case setIsPushReviewVC(Bool)
     }
     
     struct State {
         var orderList: [OrderLogItem] = OrderLogItem.exampleOrder
         var nextPage: Int = 0
+        var isPushRefundVC: Bool = false
+        var isPushReturnVC: Bool = false
+        var isPushReviewVC: Bool = false
     }
     
     var initialState: State
@@ -37,6 +46,21 @@ final class OrderLogReactor: Reactor {
             return setOrderList()
         case .loadNextPage:
             return setOrderList()
+        case .didTapRefundButton:
+            return .concat([
+                .just(.setIsPushRefundVC(true)),
+                .just(.setIsPushRefundVC(false))
+            ])
+        case .didTapReturnButton:
+            return .concat([
+                .just(.setIsPushReturnVC(true)),
+                .just(.setIsPushReturnVC(false))
+            ])
+        case .didTapReviewButton:
+            return .concat([
+                .just(.setIsPushReviewVC(true)),
+                .just(.setIsPushReviewVC(false))
+            ])
         }
     }
     
@@ -49,6 +73,15 @@ final class OrderLogReactor: Reactor {
             
         case .setNextPage(let page):
             state.nextPage = page
+            
+        case .setIsPushRefundVC(let isPush):
+            state.isPushRefundVC = isPush
+            
+        case .setIsPushReturnVC(let isPush):
+            state.isPushReturnVC = isPush
+            
+        case .setIsPushReviewVC(let isPush):
+            state.isPushReviewVC = isPush
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCategoryView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCategoryView.swift
@@ -115,7 +115,12 @@ final class OrderCategoryView: UIView {
         }
     }
     
-    func configureView() {
-        
+    func configureView(category: HBTICategory) {
+        categoryImageView.kf.setImage(with: URL(string: category.imageURL))
+        categoryLabel.text = category.name
+        noteListLabel.text = category.noteList.map { $0.name }.joined(separator: ", ")
+        quantityLabel.text = "수량 \(category.noteCount)개"
+        unitPriceLabel.text = "\(category.price / category.noteCount)/개"
+        categoryPriceLabel.text = category.price.numberFormatterToHangulWon()
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
@@ -94,6 +94,12 @@ final class OrderCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+            super.prepareForReuse()
+        
+            disposeBag = DisposeBag()
+        }
+    
     // MARK: - Function
     
     private func setUI() {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
@@ -9,10 +9,13 @@ import UIKit
 
 import Then
 import SnapKit
+import RxSwift
 
 final class OrderCell: UICollectionViewCell {
     
     static let identifier = "OrderCell"
+    
+    var disposeBag = DisposeBag()
     
     // MARK: UI Components
     
@@ -71,11 +74,11 @@ final class OrderCell: UICollectionViewCell {
         $0.spacing = 20
     }
     
-    private let refundRequestButton = UIButton().grayBorderButton(title: "환불 신청")
+    let refundRequestButton = UIButton().grayBorderButton(title: "환불 신청")
     
-    private let returnRequestButton = UIButton().grayBorderButton(title: "반품 신청")
+    let returnRequestButton = UIButton().grayBorderButton(title: "반품 신청")
     
-    private let reviewButton = UIButton().grayBorderButton(title: "후기 작성")
+    let reviewButton = UIButton().grayBorderButton(title: "후기 작성")
     
     // MARK: - Init
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
@@ -159,8 +159,8 @@ final class OrderCell: UICollectionViewCell {
     }
     
     func configureCell(order: Order) {
-        // TODO: Status에 따라 문구, 색상 변경
-        statusLabel.text = OrderStatus(rawValue: order.status)!.kr
+        setStatusLabel(for: OrderStatus(rawValue: order.status))
+        
         let categoryList = order.products.categoryListInfo.categoryList
         setCategoryStackView(categoryList)
         // TODO: 두 값이 nil이면 shippingInfoLabel.hidden = true
@@ -180,5 +180,11 @@ final class OrderCell: UICollectionViewCell {
             }
             categoryStackView.addArrangedSubview(categoryView)
         }
+    }
+    
+    private func setStatusLabel(for status: OrderStatus?) {
+        guard let status = status else { return }
+        statusLabel.text = status.kr
+        statusLabel.textColor = status.textColor
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
@@ -158,19 +158,27 @@ final class OrderCell: UICollectionViewCell {
         
     }
     
-    func configureCell() {
-        let category1 = OrderCategoryView()
-        let category2 = OrderCategoryView()
+    func configureCell(order: Order) {
+        // TODO: Status에 따라 문구, 색상 변경
+        statusLabel.text = OrderStatus(rawValue: order.status)!.kr
+        let categoryList = order.products.categoryListInfo.categoryList
+        setCategoryStackView(categoryList)
+        // TODO: 두 값이 nil이면 shippingInfoLabel.hidden = true
+        shippingInfoLabel.text = "택배사:\(order.courierCompany)\n운송장번호:\(order.trackingNumber)"
+        shippingPriceValueLabel.text = order.products.shippingFee.numberFormatterToHangulWon()
+        totalAmountValueLabel.text = order.products.totalAmount.numberFormatterToHangulWon()
+    }
+    
+    private func setCategoryStackView(_ categoryList: [HBTICategory]) {
+        categoryStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         
-        [
-            category1,
-            category2
-        ]   .forEach {
-            $0.configureView()
-            $0.snp.makeConstraints { make in
+        categoryList.forEach {
+            let categoryView = OrderCategoryView()
+            categoryView.configureView(category: $0)
+            categoryView.snp.makeConstraints { make in
                 make.height.greaterThanOrEqualTo(90)
             }
-            categoryStackView.addArrangedSubview($0)
+            categoryStackView.addArrangedSubview(categoryView)
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
@@ -35,10 +35,16 @@ final class OrderCell: UICollectionViewCell {
         $0.backgroundColor = .black
     }
     
-    private let shippingInfoLabel = UILabel().then {
+    private let shippingInfoView = UIView()
+    
+    private let shippingCompanyLabel = UILabel().then {
         $0.setLabelUI("", font: .pretendard, size: 10, color: .gray3)
-        $0.setTextWithLineHeight(text: "택배사:모아택배\n운송장번호:123456789", lineHeight: 12)
-        $0.numberOfLines = 2
+        $0.setTextWithLineHeight(text: "택배사:모아택배", lineHeight: 12)
+    }
+    
+    private let shippingTrackingNumberLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard, size: 10, color: .gray3)
+        $0.setTextWithLineHeight(text: "운송장번호:123456789", lineHeight: 12)
     }
     
     private let shippingPriceTitleLabel = UILabel().then {
@@ -92,7 +98,7 @@ final class OrderCell: UICollectionViewCell {
             statusLabel,
             decoLine,
             categoryStackView,
-            shippingInfoLabel,
+            shippingInfoView,
             shippingPriceTitleLabel,
             shippingPriceValueLabel,
             separatorLineView,
@@ -100,6 +106,11 @@ final class OrderCell: UICollectionViewCell {
             totalAmountValueLabel,
             returnRefundButton
         ]   .forEach { addSubview($0) }
+        
+        [
+            shippingCompanyLabel,
+            shippingTrackingNumberLabel
+        ]   .forEach { shippingInfoView.addSubview($0) }
     }
     
     private func setConstraints() {
@@ -119,13 +130,23 @@ final class OrderCell: UICollectionViewCell {
             make.horizontalEdges.equalToSuperview()
         }
         
-        shippingInfoLabel.snp.makeConstraints { make in
-            make.top.equalTo(categoryStackView.snp.bottom).offset(20)
+        shippingInfoView.snp.makeConstraints { make in
+            make.top.equalTo(categoryStackView.snp.bottom)
             make.leading.equalToSuperview().inset(80)
         }
         
+        shippingCompanyLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(20)
+            make.horizontalEdges.equalToSuperview()
+        }
+        
+        shippingTrackingNumberLabel.snp.makeConstraints { make in
+            make.top.equalTo(shippingCompanyLabel.snp.bottom)
+            make.horizontalEdges.bottom.equalToSuperview()
+        }
+        
         shippingPriceTitleLabel.snp.makeConstraints { make in
-            make.top.equalTo(shippingInfoLabel.snp.bottom).offset(18)
+            make.top.equalTo(shippingInfoView.snp.bottom).offset(18)
             make.trailing.equalTo(shippingPriceValueLabel.snp.leading).offset(-7)
         }
         
@@ -159,12 +180,10 @@ final class OrderCell: UICollectionViewCell {
     }
     
     func configureCell(order: Order) {
-        setStatusLabel(for: OrderStatus(rawValue: order.status))
-        
         let categoryList = order.products.categoryListInfo.categoryList
         setCategoryStackView(categoryList)
-        // TODO: 두 값이 nil이면 shippingInfoLabel.hidden = true
-        shippingInfoLabel.text = "택배사:\(order.courierCompany)\n운송장번호:\(order.trackingNumber)"
+        setStatusLabel(for: OrderStatus(rawValue: order.status))
+        setShippingInfoView(company: order.courierCompany, trackingNumber: order.trackingNumber)
         shippingPriceValueLabel.text = order.products.shippingFee.numberFormatterToHangulWon()
         totalAmountValueLabel.text = order.products.totalAmount.numberFormatterToHangulWon()
     }
@@ -186,5 +205,20 @@ final class OrderCell: UICollectionViewCell {
         guard let status = status else { return }
         statusLabel.text = status.kr
         statusLabel.textColor = status.textColor
+    }
+    
+    private func setShippingInfoView(company: String?, trackingNumber: String?) {
+        if let company = company,
+           let trackingNumber = trackingNumber {
+            shippingCompanyLabel.text = "택배사:\(company)"
+            shippingTrackingNumberLabel.text = "운송장번호:\(trackingNumber)"
+            shippingInfoView.snp.makeConstraints { make in
+                make.height.equalTo(44)
+            }
+        } else {
+            shippingInfoView.snp.makeConstraints { make in
+                make.height.equalTo(0)
+            }
+        }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -37,7 +37,6 @@ final class OrderLogViewController: UIViewController, View {
         setAddView()
         setConstraints()
         configureDataSource()
-        presentOrderCancelDetailViewController()
     }
     
     // MARK: - Bind
@@ -45,6 +44,10 @@ final class OrderLogViewController: UIViewController, View {
     func bind(reactor: OrderLogReactor) {
         
         // MARK: Action
+        rx.viewDidLoad
+            .map { Reactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: self.disposeBag)
         
         // MARK: State
     }
@@ -109,7 +112,7 @@ final class OrderLogViewController: UIViewController, View {
         var initialSnapshot = NSDiffableDataSourceSnapshot<OrderLogSection, OrderLogItem>()
         initialSnapshot.appendSections([.order])
         
-        initialSnapshot.appendItems([.order("1"), .order("2")])
+        
         
         dataSource?.apply(initialSnapshot, animatingDifferences: false)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -64,6 +64,33 @@ final class OrderLogViewController: UIViewController, View {
                 owner.updateSnapshot(forSection: .order, withItems: items)
             })
             .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isPushRefundVC }
+            .filter { $0 }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, _ in
+                owner.presentOrderCancelDetailViewController()
+            })
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isPushReturnVC }
+            .filter { $0 }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, _ in
+                owner.presentOrderCancelDetailViewController()
+            })
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isPushReviewVC }
+            .filter { $0 }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, _ in
+                owner.presentHBTIViewController()
+            })
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Functions
@@ -118,6 +145,21 @@ final class OrderLogViewController: UIViewController, View {
                     for: indexPath) as! OrderCell
                 
                 cell.configureCell(order: order)
+                
+                cell.refundRequestButton.rx.tap
+                    .map { Reactor.Action.didTapRefundButton }
+                    .bind(to: self.reactor!.action )
+                    .disposed(by: cell.disposeBag)
+                
+                cell.returnRequestButton.rx.tap
+                    .map { Reactor.Action.didTapReturnButton }
+                    .bind(to: self.reactor!.action )
+                    .disposed(by: cell.disposeBag)
+                
+                cell.reviewButton.rx.tap
+                    .map { Reactor.Action.didTapReviewButton }
+                    .bind(to: self.reactor!.action )
+                    .disposed(by: cell.disposeBag)
                 
                 return cell
             }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -49,9 +49,16 @@ final class OrderLogViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
+        orderCollectionView.rx.willDisplayCell
+            .filter { $0.at.item == self.orderCollectionView.numberOfItems(inSection: 0) - 1 }
+            .map { _ in Reactor.Action.loadNextPage }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: State
         reactor.state
             .map { $0.orderList }
+            .distinctUntilChanged()
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, items in
                 owner.updateSnapshot(forSection: .order, withItems: items)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -50,6 +50,13 @@ final class OrderLogViewController: UIViewController, View {
             .disposed(by: self.disposeBag)
         
         // MARK: State
+        reactor.state
+            .map { $0.orderList }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, items in
+                owner.updateSnapshot(forSection: .order, withItems: items)
+            })
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Functions
@@ -103,7 +110,7 @@ final class OrderLogViewController: UIViewController, View {
                     withReuseIdentifier: OrderCell.identifier,
                     for: indexPath) as! OrderCell
                 
-                cell.configureCell()
+                cell.configureCell(order: order)
                 
                 return cell
             }
@@ -112,9 +119,17 @@ final class OrderLogViewController: UIViewController, View {
         var initialSnapshot = NSDiffableDataSourceSnapshot<OrderLogSection, OrderLogItem>()
         initialSnapshot.appendSections([.order])
         
-        
-        
         dataSource?.apply(initialSnapshot, animatingDifferences: false)
+    }
+    
+    private func updateSnapshot(forSection section: OrderLogSection, withItems items: [OrderLogItem]) {
+        guard let dataSource = self.dataSource else { return }
+        
+        var snapshot = dataSource.snapshot()
+        
+        snapshot.appendItems(items, toSection: section)
+        
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 
 }


### PR DESCRIPTION
# 📌 이슈번호
- #251 

# 📌 구현/추가 사항
- UIButtonExtension에 주문내역에서만 사용할 것 같은 버튼을 만드는 함수를 추가했는데, 주문내역 외에도 사용할 수 있을 것 같아서 grayLineButton 처럼 외형을 설명하는 네이밍이 나을지 피드백 부탁드립니다.
- HBTICategory, HBTINote 모델을 추가했습니다. 향BTI 1차 후반부에도 사용되는 모델이니 참고해주세요.
- 취소/환불 상세화면으로 push하기만 하고, 취소인지 환불인지에 따라 UI를 변경하는 기능은 해당VC 작업할 때 추가하겠습니다.
- 서버쪽에서 제 계정에 주문내역을 추가해주시긴 했는데, 다양항 상황을 반영하고 있지는 않아서 임의의 샘플을 추가했습니다. 프로젝트 마무리단계에서 삭제하겠습니다.
- 후기 작성 버튼은 임의로 향BTI 홈으로 이동하도록 했으며, 후기화면 구현 후 변경하겠습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/94d6dee4-3fb4-4a27-8a88-03d04f95021f


