### PR TITLE
[New Feature] 취소/반품 상세화면 상호작용

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		C99E7B6B2BA9F0B500F359BC /* MagazineDetailLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99E7B6A2BA9F0B500F359BC /* MagazineDetailLineView.swift */; };
 		C9B02B492CA24A0F00F1107C /* OrderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B02B482CA24A0F00F1107C /* OrderCell.swift */; };
 		C9B02B4D2CA25A0E00F1107C /* OrderCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B02B4C2CA25A0E00F1107C /* OrderCategoryView.swift */; };
+		C9CDA4FF2CB3BFBE001091F1 /* OrderCancelRequestKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CDA4FE2CB3BFBE001091F1 /* OrderCancelRequestKind.swift */; };
 		C9D161E52C1FF2550032FE78 /* IgnoerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D161E42C1FF2550032FE78 /* IgnoerData.swift */; };
 		C9D2300B2C69F601008ACB9B /* HBTILoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */; };
 		C9D2300D2C6AE106008ACB9B /* HBTISurveyResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */; };
@@ -520,6 +521,7 @@
 		C99E7B6A2BA9F0B500F359BC /* MagazineDetailLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineDetailLineView.swift; sourceTree = "<group>"; };
 		C9B02B482CA24A0F00F1107C /* OrderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCell.swift; sourceTree = "<group>"; };
 		C9B02B4C2CA25A0E00F1107C /* OrderCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCategoryView.swift; sourceTree = "<group>"; };
+		C9CDA4FE2CB3BFBE001091F1 /* OrderCancelRequestKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCancelRequestKind.swift; sourceTree = "<group>"; };
 		C9D161E42C1FF2550032FE78 /* IgnoerData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IgnoerData.swift; path = ../../../../../../../../../Downloads/IgnoerData.swift; sourceTree = "<group>"; };
 		C9D2300A2C69F601008ACB9B /* HBTILoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTILoadingView.swift; sourceTree = "<group>"; };
 		C9D2300C2C6AE106008ACB9B /* HBTISurveyResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTISurveyResultCell.swift; sourceTree = "<group>"; };
@@ -1624,6 +1626,7 @@
 		C93AC2F02CA58418004A1CF5 /* OrderCancelDetail */ = {
 			isa = PBXGroup;
 			children = (
+				C9CDA4FD2CB3BF96001091F1 /* Model */,
 				C93AC2F72CA58B56004A1CF5 /* View */,
 				C93AC2F12CA58478004A1CF5 /* Reactor */,
 				C93AC2F22CA58481004A1CF5 /* ViewController */,
@@ -2041,6 +2044,14 @@
 			isa = PBXGroup;
 			children = (
 				C99E7B682BA96DE200F359BC /* MagazineDetailItem.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		C9CDA4FD2CB3BF96001091F1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				C9CDA4FE2CB3BFBE001091F1 /* OrderCancelRequestKind.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -3278,6 +3289,7 @@
 				C99E7B692BA96DE200F359BC /* MagazineDetailItem.swift in Sources */,
 				CA6CA1122AFF780300535B0D /* CommunityPostPhotoCell.swift in Sources */,
 				CA1067DB29D6CFC2009A7245 /* ChangeSexViewController.swift in Sources */,
+				C9CDA4FF2CB3BFBE001091F1 /* OrderCancelRequestKind.swift in Sources */,
 				CAFE2F1E2B0F414700054E22 /* HpediaType.swift in Sources */,
 				C98E04282C2C6CE500225624 /* PushAlarmCell.swift in Sources */,
 				2C4DD3742976E1A70027CE40 /* HomeView.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -308,9 +308,9 @@ extension UIViewController {
     }
     
     /// OrderCancelDetailVC로 push
-    func presentOrderCancelDetailViewController(orderCancelRequest: OrderCancelRequestKind) {
+    func presentOrderCancelDetailViewController(_ order: OrderLogItem, orderCancelRequest: OrderCancelRequestKind) {
         let orderCancelDetailVC = OrderCancelDetailViewController()
-        orderCancelDetailVC.reactor = OrderCancelDetailReactor(orderCancelRequest)
+        orderCancelDetailVC.reactor = OrderCancelDetailReactor(order, orderCancelRequest)
         orderCancelDetailVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(orderCancelDetailVC, animated: true)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -308,9 +308,9 @@ extension UIViewController {
     }
     
     /// OrderCancelDetailVC로 push
-    func presentOrderCancelDetailViewController() {
+    func presentOrderCancelDetailViewController(orderCancelRequest: OrderCancelRequestKind) {
         let orderCancelDetailVC = OrderCancelDetailViewController()
-        orderCancelDetailVC.reactor = OrderCancelDetailReactor()
+        orderCancelDetailVC.reactor = OrderCancelDetailReactor(orderCancelRequest)
         orderCancelDetailVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(orderCancelDetailVC, animated: true)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/Model/OrderCancelRequestKind.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/Model/OrderCancelRequestKind.swift
@@ -1,0 +1,13 @@
+//
+//  OrderCancelRequestKind.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 10/7/24.
+//
+
+import Foundation
+
+enum OrderCancelRequestKind {
+    case refundRequest
+    case returnRequest
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/Reactor/OrderCancelDetailReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/Reactor/OrderCancelDetailReactor.swift
@@ -13,24 +13,28 @@ import RxSwift
 final class OrderCancelDetailReactor: Reactor {
     
     enum Action {
+        case viewDidLoad
     }
     
     enum Mutation {
+        case setOrder(OrderLogItem)
     }
     
     struct State {
+        var order: OrderLogItem
         var requestKind: OrderCancelRequestKind
     }
     
     var initialState: State
     
-    init(_ orderCancelRequest: OrderCancelRequestKind) {
-        self.initialState = State(requestKind: orderCancelRequest)
+    init(_ order: OrderLogItem, _ orderCancelRequest: OrderCancelRequestKind) {
+        self.initialState = State(order: order, requestKind: orderCancelRequest)
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        
+        case .viewDidLoad:
+            return .just(.setOrder(currentState.order))
         }
     }
     
@@ -38,6 +42,8 @@ final class OrderCancelDetailReactor: Reactor {
         var state = state
         
         switch mutation {
+        case .setOrder(let order):
+            state.order = order
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/Reactor/OrderCancelDetailReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/Reactor/OrderCancelDetailReactor.swift
@@ -14,15 +14,18 @@ final class OrderCancelDetailReactor: Reactor {
     
     enum Action {
         case viewDidLoad
+        case didTapRequestButton
     }
     
     enum Mutation {
         case setOrder(OrderLogItem)
+        case setIsNextVC(Bool)
     }
     
     struct State {
         var order: OrderLogItem
         var requestKind: OrderCancelRequestKind
+        var isPushNextVC: Bool = false
     }
     
     var initialState: State
@@ -35,6 +38,12 @@ final class OrderCancelDetailReactor: Reactor {
         switch action {
         case .viewDidLoad:
             return .just(.setOrder(currentState.order))
+            
+        case .didTapRequestButton:
+            return .concat([
+                .just(.setIsNextVC(true)),
+                .just(.setIsNextVC(false))
+            ])
         }
     }
     
@@ -44,6 +53,9 @@ final class OrderCancelDetailReactor: Reactor {
         switch mutation {
         case .setOrder(let order):
             state.order = order
+            
+        case .setIsNextVC(let isPush):
+            state.isPushNextVC = isPush
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/Reactor/OrderCancelDetailReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/Reactor/OrderCancelDetailReactor.swift
@@ -13,26 +13,24 @@ import RxSwift
 final class OrderCancelDetailReactor: Reactor {
     
     enum Action {
-        
     }
     
     enum Mutation {
-        
     }
     
     struct State {
-        
+        var requestKind: OrderCancelRequestKind
     }
     
     var initialState: State
     
-    init() {
-        self.initialState = State()
+    init(_ orderCancelRequest: OrderCancelRequestKind) {
+        self.initialState = State(requestKind: orderCancelRequest)
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-            
+        
         }
     }
     
@@ -40,7 +38,6 @@ final class OrderCancelDetailReactor: Reactor {
         var state = state
         
         switch mutation {
-            
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/View/OrderCancelCategoryView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/View/OrderCancelCategoryView.swift
@@ -114,8 +114,13 @@ final class OrderCancelCategoryView: UIView {
         }
     }
     
-    func configureView() {
-        
+    func configureView(category: HBTICategory) {
+        categoryImageView.kf.setImage(with: URL(string: category.imageURL))
+        categoryLabel.text = category.name
+        noteListLabel.text = category.noteList.map { $0.name }.joined(separator: ", ")
+        quantityLabel.text = "수량 \(category.noteCount)개"
+        unitPriceLabel.text = "\(category.price / category.noteCount)/개"
+        categoryPriceLabel.text = category.price.numberFormatterToHangulWon()
     }
     
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
@@ -92,6 +92,15 @@ final class OrderCancelDetailViewController: UIViewController, View {
         // MARK: Action
         
         // MARK: State
+        
+        reactor.state
+            .map { $0.requestKind }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, requestKind in
+                owner.paymentInfoView.isHidden = requestKind == .returnRequest
+                owner.setCancelButtonTitleLabel(requestKind)
+            })
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Functions
@@ -216,6 +225,16 @@ final class OrderCancelDetailViewController: UIViewController, View {
             make.horizontalEdges.equalTo(categoryStackView.snp.horizontalEdges)
             make.bottom.equalToSuperview().inset(40)
             make.height.equalTo(52)
+        }
+    }
+}
+
+extension OrderCancelDetailViewController {
+    private func setCancelButtonTitleLabel(_ requestKind: OrderCancelRequestKind) {
+        if requestKind == .refundRequest {
+            cancelButton.setTitle("환불 신청", for: .normal)
+        } else {
+            cancelButton.setTitle("반품 신청(1대 1 문의)", for: .normal)
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
@@ -90,6 +90,10 @@ final class OrderCancelDetailViewController: UIViewController, View {
     func bind(reactor: OrderCancelDetailReactor) {
         
         // MARK: Action
+        rx.viewDidLoad
+            .map { Reactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         
         // MARK: State
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/View/OrderCancelLogCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/View/OrderCancelLogCell.swift
@@ -97,7 +97,7 @@ final class OrderCancelLogCell: UITableViewCell {
             category1,
             category2
         ]   .forEach {
-            $0.configureView()
+            // configureView()
             $0.snp.makeConstraints { make in
                 make.height.greaterThanOrEqualTo(60)
             }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
@@ -13,14 +13,15 @@ final class OrderLogReactor: Reactor {
     enum Action {
         case viewDidLoad
         case loadNextPage
-        case didTapRefundButton
-        case didTapReturnButton
+        case didTapRefundButton(OrderLogItem)
+        case didTapReturnButton(OrderLogItem)
         case didTapReviewButton
     }
     
     enum Mutation {
         case setOrderList([OrderLogItem])
         case setNextPage(Int)
+        case setSelectedOrder(OrderLogItem?)
         case setIsPushRefundVC(Bool)
         case setIsPushReturnVC(Bool)
         case setIsPushReviewVC(Bool)
@@ -29,6 +30,7 @@ final class OrderLogReactor: Reactor {
     struct State {
         var orderList: [OrderLogItem] = OrderLogItem.exampleOrder
         var nextPage: Int = 0
+        var selectedOrder: OrderLogItem? = nil
         var isPushRefundVC: Bool = false
         var isPushReturnVC: Bool = false
         var isPushReviewVC: Bool = false
@@ -44,18 +46,26 @@ final class OrderLogReactor: Reactor {
         switch action {
         case .viewDidLoad:
             return setOrderList()
+            
         case .loadNextPage:
             return setOrderList()
-        case .didTapRefundButton:
+            
+        case .didTapRefundButton(let order):
             return .concat([
+                .just(.setSelectedOrder(order)),
                 .just(.setIsPushRefundVC(true)),
+                .just(.setSelectedOrder(nil)),
                 .just(.setIsPushRefundVC(false))
             ])
-        case .didTapReturnButton:
+            
+        case .didTapReturnButton(let order):
             return .concat([
+                .just(.setSelectedOrder(order)),
                 .just(.setIsPushReturnVC(true)),
+                .just(.setSelectedOrder(nil)),
                 .just(.setIsPushReturnVC(false))
             ])
+            
         case .didTapReviewButton:
             return .concat([
                 .just(.setIsPushReviewVC(true)),
@@ -73,6 +83,9 @@ final class OrderLogReactor: Reactor {
             
         case .setNextPage(let page):
             state.nextPage = page
+            
+        case .setSelectedOrder(let order):
+            state.selectedOrder = order
             
         case .setIsPushRefundVC(let isPush):
             state.isPushRefundVC = isPush

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -69,9 +69,10 @@ final class OrderLogViewController: UIViewController, View {
             .map { $0.isPushRefundVC }
             .filter { $0 }
             .asDriver(onErrorRecover: { _ in .empty() })
-            .drive(with: self, onNext: { owner, _ in
-                owner.presentOrderCancelDetailViewController(orderCancelRequest: .refundRequest)
-            })
+            .drive(with: self) { owner, _ in
+                guard let order = reactor.currentState.selectedOrder else { return }
+                owner.presentOrderCancelDetailViewController(order, orderCancelRequest: .refundRequest)
+            }
             .disposed(by: disposeBag)
         
         reactor.state
@@ -79,7 +80,8 @@ final class OrderLogViewController: UIViewController, View {
             .filter { $0 }
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, _ in
-                owner.presentOrderCancelDetailViewController(orderCancelRequest: .returnRequest)
+                guard let order = reactor.currentState.selectedOrder else { return }
+                owner.presentOrderCancelDetailViewController(order, orderCancelRequest: .returnRequest)
             })
             .disposed(by: disposeBag)
         
@@ -147,12 +149,12 @@ final class OrderLogViewController: UIViewController, View {
                 cell.configureCell(order: order)
                 
                 cell.refundRequestButton.rx.tap
-                    .map { Reactor.Action.didTapRefundButton }
+                    .map { Reactor.Action.didTapRefundButton(item) }
                     .bind(to: self.reactor!.action )
                     .disposed(by: cell.disposeBag)
                 
                 cell.returnRequestButton.rx.tap
-                    .map { Reactor.Action.didTapReturnButton }
+                    .map { Reactor.Action.didTapReturnButton(item) }
                     .bind(to: self.reactor!.action )
                     .disposed(by: cell.disposeBag)
                 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -70,7 +70,7 @@ final class OrderLogViewController: UIViewController, View {
             .filter { $0 }
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, _ in
-                owner.presentOrderCancelDetailViewController()
+                owner.presentOrderCancelDetailViewController(orderCancelRequest: .refundRequest)
             })
             .disposed(by: disposeBag)
         
@@ -79,7 +79,7 @@ final class OrderLogViewController: UIViewController, View {
             .filter { $0 }
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, _ in
-                owner.presentOrderCancelDetailViewController()
+                owner.presentOrderCancelDetailViewController(orderCancelRequest: .returnRequest)
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
# 📌 이슈번호
- #257

# 📌 구현/추가 사항
- 환불 신청과 반품 신청이 하나의 VC를 공유하고 있고, request 종류에 따라서 뷰의 모습이나 버튼 동작이 달라지도록 구현했습니다.
- request 버튼을 눌렀을 때 requestKind가 반품일 경우 카카오 문의로 넘어가도록 구현했고, 환불일 경우에는 부트페이 환불 기능 연동해주시면 됩니다!

# 📷 미리보기
https://github.com/user-attachments/assets/896621bc-783a-4ee9-9e5c-8119c97bd941
