### PR TITLE
[New Feature] 취소/반품내역 네트워킹

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/MemberAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/MemberAPI.swift
@@ -207,4 +207,13 @@ final class MemberAPI {
             model: OrderResponse.self,
             query: query)
     }
+    
+    static func fetchOrderCancelList(_ query: [String: Int]) -> Observable<OrderResponse> {
+        return networking(
+            urlStr: MemberAddress.fetchOrderCancel.url,
+            method: .get,
+            data: nil,
+            model: OrderResponse.self,
+            query: query)
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/MemberAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/MemberAddress.swift
@@ -22,6 +22,7 @@ enum MemberAddress {
     case fetchWritedPost
     case deleteMember
     case fetchOrder
+    case fetchOrderCancel
 }
 
 extension MemberAddress {
@@ -55,6 +56,8 @@ extension MemberAddress {
             return "member/delete"
         case .fetchOrder:
             return "member/order"
+        case .fetchOrderCancel:
+            return "member/order/cancel"
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/Model/OrderCancelLogSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/Model/OrderCancelLogSection.swift
@@ -12,12 +12,11 @@ enum OrderCancelLogSection: Hashable {
 }
 
 enum OrderCancelLogItem: Hashable {
-    // TODO: Networking Model 정의 후 String에서 교체
-    case order(String)
+    case order(Order)
 }
 
 extension OrderCancelLogItem {
-    var order: String? {
+    var order: Order? {
         if case .order(let order) = self {
             return order
         } else {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/Reactor/OrderCancelLogReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/Reactor/OrderCancelLogReactor.swift
@@ -12,14 +12,17 @@ final class OrderCancelLogReactor: Reactor {
 
     enum Action {
         case viewDidLoad
+        case loadNextPage
     }
 
     enum Mutation {
         case setOrderCancelList([OrderCancelLogItem])
+        case setNextPage(Int)
     }
 
     struct State {
         var orderCancelList: [OrderCancelLogItem] = []
+        var nextPage: Int = 0
     }
 
     var initialState: State
@@ -32,6 +35,9 @@ final class OrderCancelLogReactor: Reactor {
         switch action {
         case .viewDidLoad:
             return setOrderCancelList()
+            
+        case .loadNextPage:
+            return setOrderCancelList()
         }
     }
 
@@ -40,7 +46,10 @@ final class OrderCancelLogReactor: Reactor {
 
         switch mutation {
         case .setOrderCancelList(let list):
-            state.orderCancelList = list
+            state.orderCancelList += list
+            
+        case .setNextPage(let page):
+            state.nextPage = page
         }
 
         return state
@@ -49,7 +58,8 @@ final class OrderCancelLogReactor: Reactor {
 
 extension OrderCancelLogReactor {
     func setOrderCancelList() -> Observable<Mutation> {
-        let query: [String: Int] = ["cursor": 0]
+        let page = currentState.nextPage
+        let query: [String: Int] = ["cursor": page]
         
         return MemberAPI.fetchOrderCancelList(query)
             .catch { _ in .empty() }
@@ -58,7 +68,8 @@ extension OrderCancelLogReactor {
                     return OrderCancelLogItem.order(order)
                 }
                 return .concat([
-                    .just(.setOrderCancelList(orderItemList))
+                    .just(.setOrderCancelList(orderItemList)),
+                    .just(.setNextPage(page + 1))
                 ])
             }
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/Reactor/OrderCancelLogReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/Reactor/OrderCancelLogReactor.swift
@@ -11,15 +11,15 @@ import RxSwift
 final class OrderCancelLogReactor: Reactor {
 
     enum Action {
-
+        case viewDidLoad
     }
 
     enum Mutation {
-
+        case setOrderCancelList([OrderCancelLogItem])
     }
 
     struct State {
-
+        var orderCancelList: [OrderCancelLogItem] = []
     }
 
     var initialState: State
@@ -30,7 +30,8 @@ final class OrderCancelLogReactor: Reactor {
 
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-
+        case .viewDidLoad:
+            return setOrderCancelList()
         }
     }
 
@@ -38,9 +39,27 @@ final class OrderCancelLogReactor: Reactor {
         var state = state
 
         switch mutation {
-
+        case .setOrderCancelList(let list):
+            state.orderCancelList = list
         }
 
         return state
+    }
+}
+
+extension OrderCancelLogReactor {
+    func setOrderCancelList() -> Observable<Mutation> {
+        let query: [String: Int] = ["cursor": 0]
+        
+        return MemberAPI.fetchOrderCancelList(query)
+            .catch { _ in .empty() }
+            .flatMap { OrderResponseData -> Observable<Mutation> in
+                let orderItemList = OrderResponseData.orders.map { order in
+                    return OrderCancelLogItem.order(order)
+                }
+                return .concat([
+                    .just(.setOrderCancelList(orderItemList))
+                ])
+            }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/View/OrderCancelLogCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/View/OrderCancelLogCell.swift
@@ -72,7 +72,7 @@ final class OrderCancelLogCell: UITableViewCell {
         decoLine.snp.makeConstraints { make in
             make.centerY.equalTo(statusLabel.snp.centerY)
             make.leading.equalTo(statusLabel.snp.trailing).offset(16)
-            make.trailing.equalToSuperview()
+            make.trailing.equalTo(dateLabel.snp.leading).offset(-12)
             make.height.equalTo(1)
         }
         
@@ -89,20 +89,34 @@ final class OrderCancelLogCell: UITableViewCell {
         }
     }
     
-    func configureCell() {
-        let category1 = OrderCancelCategoryView()
-        let category2 = OrderCancelCategoryView()
+    func configureCell(order: Order) {
+        let status = OrderStatus(rawValue: order.status)
+        let categoryList = order.products.categoryListInfo.categoryList
         
-        [
-            category1,
-            category2
-        ]   .forEach {
-            // configureView()
-            $0.snp.makeConstraints { make in
-                make.height.greaterThanOrEqualTo(60)
+        setStatusLabel(for: status)
+        setCategoryStackView(categoryList)
+        dateLabel.setLabelUI(order.createdAt, font: .pretendard_bold, size: 12, color: .gray3)
+    }
+    
+}
+
+extension OrderCancelLogCell {
+    private func setCategoryStackView(_ categoryList: [HBTICategory]) {
+        categoryStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
+        categoryList.forEach {
+            let categoryView = OrderCancelCategoryView()
+            categoryView.configureView(category: $0)
+            categoryView.snp.makeConstraints { make in
+                make.height.greaterThanOrEqualTo(61)
             }
-            categoryStackView.addArrangedSubview($0)
+            categoryStackView.addArrangedSubview(categoryView)
         }
     }
-
+    
+    private func setStatusLabel(for status: OrderStatus?) {
+        guard let status = status else { return }
+        statusLabel.text = status.kr
+        statusLabel.textColor = status.textColor
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/ViewController/OrderCancelLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/ViewController/OrderCancelLogViewController.swift
@@ -42,7 +42,11 @@ final class OrderCancelLogViewController: UIViewController, View {
     func bind(reactor: OrderCancelLogReactor) {
 
         // MARK: Action
-
+        rx.viewDidLoad
+            .map { Reactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: State
     }
 
@@ -90,7 +94,6 @@ final class OrderCancelLogViewController: UIViewController, View {
         
         var initialSnapshot = NSDiffableDataSourceSnapshot<OrderCancelLogSection, OrderCancelLogItem>()
         initialSnapshot.appendSections([.cancel])
-        initialSnapshot.appendItems([.order("1"), .order("2")])
         
         dataSource?.apply(initialSnapshot)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/ViewController/OrderCancelLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/ViewController/OrderCancelLogViewController.swift
@@ -47,6 +47,12 @@ final class OrderCancelLogViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        orderCancelLogTableView.rx.willDisplayCell
+            .filter { $0.indexPath.row == self.orderCancelLogTableView.numberOfRows(inSection: 0) - 1 }
+            .map { _ in Reactor.Action.loadNextPage }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: State
         
         reactor.state


### PR DESCRIPTION
# 📌 이슈번호
- #260 

# 📌 구현/추가 사항
- 마이페이지의 취소/반품 내역 조회 시 서버 데이터를 fetch, UI에 적용하는 작업을 마쳤습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/a6d4acb3-bd08-41f2-aab1-b556e9d83551