### PR TITLE
[New Feature] 향BTI 신고기능 추가 등

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -315,6 +315,15 @@ extension UIViewController {
         self.navigationController?.pushViewController(hbtiReviewWriteVC, animated: true)
     }
     
+    func presentHBTIReviewWriteViewController(reviewID: Int, content: String, communityPhotos: [CommunityPhoto]) {
+        let hbtiReviewWriteVC = HBTIReviewWriteViewController()
+        hbtiReviewWriteVC.reactor = HBTIReviewWriteReactor(reviewID: reviewID,
+                                                           content: content,
+                                                           photos: communityPhotos)
+        hbtiReviewWriteVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(hbtiReviewWriteVC, animated: true)
+    }
+    
     /// HBTIReviewListVC로 push
     func presentHBTIReviewListViewController(isLog: Bool) {
         let hbtiReviewListVC = HBTIReviewListViewController()

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -65,8 +65,8 @@ extension UIViewController {
     }
     
     /// CustomAlertVC로 present
-    func presentAlertVC(title: String, content: String, buttonTitle: String) {
-        let alertVC = AlertViewController(title: title, content: content, buttonTitle: buttonTitle)
+    func presentAlertVC(title: String, content: String, buttonTitle: String, type: AlertType? = nil) {
+        let alertVC = AlertViewController(title: title, content: content, buttonTitle: buttonTitle, type: type)
         alertVC.modalPresentationStyle = .overFullScreen
         self.present(alertVC, animated: false)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
@@ -8,6 +8,14 @@
 import RxSwift
 
 final class HBTIAPI {
+    static func fetchHomeInfo() -> Observable<HBTIHomeInfo> {
+        return networking(
+            urlStr: HBTIAddress.fetchHomeInfo.url,
+            method: .get,
+            data: nil,
+            model: HBTIHomeInfo.self)
+    }
+    
     static func fetchSurvey() -> Observable<HBTISurveyResponse> {
         return networking(
             urlStr: HBTIAddress.fetchQuestionList.url,

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
@@ -104,4 +104,12 @@ final class HBTIAPI {
             parameter: params,
             model: HBTIReview.self)
     }
+    
+    static func deleteReivew(id: Int) -> Observable<Response> {
+        return networking(
+            urlStr: HBTIAddress.editDeleteReview(id).url,
+            method: .delete,
+            data: nil,
+            model: Response.self)
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAPI.swift
@@ -112,4 +112,22 @@ final class HBTIAPI {
             data: nil,
             model: Response.self)
     }
+    
+    static func editReview(reviewID: Int, params: [String: Any], images: [UIImage]) -> Observable<HBTIReview> {
+        var imageData: [Data]?
+        
+        if images.isEmpty {
+            imageData = nil
+        } else {
+            imageData = images.compactMap { $0.resize(targetSize: $0.size)?.jpegData(compressionQuality: 0.1) }
+        }
+        
+        return uploadNetworking(
+            urlStr: HBTIAddress.editDeleteReview(reviewID).url,
+            method: .post,
+            imageData: imageData,
+            imageFileName: "reviewImage.jpeg",
+            parameter: params,
+            model: HBTIReview.self)
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum HBTIAddress {
+    case fetchHomeInfo
     case fetchQuestionList
     case postAnswerList
     case fetchPerfumeSurvey
@@ -21,6 +22,8 @@ enum HBTIAddress {
     
     var url: String {
         switch self {
+        case .fetchHomeInfo:
+            return "survey/home"
         case .fetchQuestionList:
             return "survey/note"
         case .postAnswerList:

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/HBTIAddress.swift
@@ -17,6 +17,7 @@ enum HBTIAddress {
     case fetchNotReviewedOrderList
     case fetchPostedReview
     case postReview
+    case editDeleteReview(Int)
     
     var url: String {
         switch self {
@@ -38,6 +39,8 @@ enum HBTIAddress {
             return "shop/review/me"
         case .postReview:
             return "shop/review"
+        case .editDeleteReview(let id):
+            return "shop/review/\(id)"
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
@@ -9,6 +9,20 @@ import Foundation
 
 // TODO: Model 파일 분리?
 
+struct HBTIHomeInfo: Codable {
+    let backgroundImageURL: String
+    let noteSurveyImageURL: String
+    let perfumeSurveyImageURL: String
+    let isOrdered: Bool
+    
+    enum CodingKeys: String, CodingKey {
+        case backgroundImageURL = "backgroundImgUrl"
+        case noteSurveyImageURL = "firstImgUrl"
+        case perfumeSurveyImageURL = "secondImgUrl"
+        case isOrdered
+    }
+}
+
 // 1차 전반부 (향BTI 결과까지)
 struct HBTISurveyResponse: Hashable, Codable {
     let title: String

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/HBTI/Model/HBTIModel.swift
@@ -17,8 +17,8 @@ struct HBTIHomeInfo: Codable {
     
     enum CodingKeys: String, CodingKey {
         case backgroundImageURL = "backgroundImgUrl"
-        case noteSurveyImageURL = "firstImgUrl"
-        case perfumeSurveyImageURL = "secondImgUrl"
+        case noteSurveyImageURL = "firstImageUrl"
+        case perfumeSurveyImageURL = "secondImageUrl"
         case isOrdered
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Report/ReportAddress.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Report/ReportAddress.swift
@@ -11,6 +11,7 @@ enum ReportAddress {
     case reportCommunity
     case reportCommunityComment
     case reportPerfumeComment
+    case reportReview(Int)
 }
 
 extension ReportAddress {
@@ -22,7 +23,8 @@ extension ReportAddress {
             return "report/communityComment"
         case .reportPerfumeComment:
             return "report/perfumeComment"
-            
+        case .reportReview(let id):
+            return "report/hbti-review/\(id)"
         }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
@@ -11,8 +11,7 @@ import Then
 import SnapKit
 import RxSwift
 
-class AlertViewController: UIViewController {
-    
+final class AlertViewController: UIViewController {
     
     let alertView = UIView().then {
         $0.backgroundColor = .white
@@ -29,18 +28,19 @@ class AlertViewController: UIViewController {
         $0.setLabelUI("", font: .pretendard, size: 12, color: .gray3)
     }
     
-    let loginButton = UIButton().then {
+    let bottomButton = UIButton().then {
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.font = .customFont(.pretendard, 12)
         $0.backgroundColor = .customColor(.gray3)
     }
 
+    var alertType: AlertType = .login
+    
     let disposeBag = DisposeBag()
 
-    init(title: String, content: String, buttonTitle: String) {
+    init(title: String, content: String, buttonTitle: String, type: AlertType? = nil) {
         super .init(nibName: nil, bundle: nil)
-        self.updateAlertView(title: title, content: content, buttonTitle: buttonTitle)
-        
+        self.updateAlertView(title: title, content: content, buttonTitle: buttonTitle, type: type)
     }
     
     required init?(coder: NSCoder) {
@@ -65,7 +65,7 @@ class AlertViewController: UIViewController {
             xButton,
             titleLabel,
             contentLabel,
-            loginButton
+            bottomButton
         ]   .forEach { alertView.addSubview($0) }
         
         view.addSubview(alertView)
@@ -93,7 +93,7 @@ class AlertViewController: UIViewController {
             make.top.equalTo(titleLabel.snp.bottom).offset(9)
         }
         
-        loginButton.snp.makeConstraints { make in
+        bottomButton.snp.makeConstraints { make in
             make.bottom.leading.trailing.equalToSuperview()
             make.height.equalTo(40)
         }
@@ -106,22 +106,35 @@ class AlertViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        loginButton.rx.tap
+        bottomButton.rx.tap
             .bind(with: self) { owner, _ in
-                guard let presentingVC = owner.presentingViewController else { return }
-                let loginVC = LoginViewController()
-                loginVC.modalPresentationStyle = .fullScreen
-                loginVC.reactor = LoginReactor(.inApp)
-                owner.dismiss(animated: false) {
-                    presentingVC.present(loginVC, animated: true)
+                switch owner.alertType {
+                case .login:
+                    guard let presentingVC = owner.presentingViewController else { return }
+                    let loginVC = LoginViewController()
+                    loginVC.modalPresentationStyle = .fullScreen
+                    loginVC.reactor = LoginReactor(.inApp)
+                    owner.dismiss(animated: false) {
+                        presentingVC.present(loginVC, animated: true)
+                    }
+                case .order:
+                    owner.dismiss(animated: false)
                 }
             }
             .disposed(by: disposeBag)
     }
     
-    func updateAlertView(title: String, content: String, buttonTitle: String) {
+    func updateAlertView(title: String, content: String, buttonTitle: String, type: AlertType?) {
         titleLabel.text = title
         contentLabel.text = content
-        loginButton.setTitle(buttonTitle, for: .normal)
+        bottomButton.setTitle(buttonTitle, for: .normal)
+        
+        guard let type = type else { return }
+        alertType = type
     }
+}
+
+enum AlertType {
+    case login
+    case order
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/Model/OptionData.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/Model/OptionData.swift
@@ -19,6 +19,7 @@ enum CommentReactorType {
 enum OptionType {
     case Post(OptionPostData)
     case Comment(OptionCommentData)
+    case Review(OptionReviewData)
 }
     
 struct OptionPostData {
@@ -34,6 +35,12 @@ struct OptionCommentData {
     let content: String
     let isWrited: Bool
     let isCommunity: Bool
+}
+
+struct OptionReviewData {
+    let id: Int
+    let content: String
+    let isWrited: Bool
 }
 
 extension CommentReactorType {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/Reactor/OptionReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/Reactor/OptionReactor.swift
@@ -132,6 +132,13 @@ final class OptionReactor: Reactor {
                     } else { return deletePerfumeComment() }
                 case .Post(_):
                     return deletePost()
+                case .Review(_):
+                    // TODO: API 연동 후 아래 실행
+                    return .concat([
+                        .just(.setisHiddenOptionView(true)),
+                        .just(.setIsTapDelete(true)),
+                        .just(.setIsTapDelete(false))
+                    ])
                 default: return .empty()
                 }
             case "신고":

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/Reactor/OptionReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/Reactor/OptionReactor.swift
@@ -291,6 +291,19 @@ extension OptionReactor {
                     ])
             }
             
+        case .Review(let data):
+            return ReportAPI.reportContent(
+                ["reviewId": data.id],
+                .reportReview(data.id))
+            .catch { _ in .empty() }
+            .flatMap { _ -> Observable<Mutation> in
+                    .concat([
+                        .just(.setisHiddenOptionView(true)),
+                        .just(.setIsReport(true)),
+                        .just(.setIsReport(false))
+                    ])
+            }
+            
         default: return .empty()
         }
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/Reactor/OptionReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/Reactor/OptionReactor.swift
@@ -27,6 +27,7 @@ final class OptionReactor: Reactor {
         case setIsTapDelete(Bool)
         case setCommentData(OptionCommentData)
         case setPostData(OptionPostData)
+        case setReviewData(OptionReviewData)
         case setType(OptionType)
         case setOptions([String])
         case delete
@@ -41,6 +42,7 @@ final class OptionReactor: Reactor {
         var isTapDelete: Bool = false
         var commentData: OptionCommentData? = nil
         var postData: OptionPostData? = nil
+        var reviewData: OptionReviewData? = nil
         var type: OptionType? = nil
         var category: String = ""
         var isTapReport: Bool = false
@@ -89,6 +91,23 @@ final class OptionReactor: Reactor {
                     return .concat([
                         .just(.setOptions(["신고"])),
                         .just(.setCommentData(commentData)),
+                        .just(.setisHiddenOptionView(false)),
+                        .just(.setType(type))
+                    ])
+                }
+                
+            case .Review(let reviewData):
+                if reviewData.isWrited {
+                    return .concat([
+                        .just(.setOptions(["수정", "삭제"])),
+                        .just(.setReviewData(reviewData)),
+                        .just(.setisHiddenOptionView(false)),
+                        .just(.setType(type))
+                    ])
+                } else {
+                    return .concat([
+                        .just(.setOptions(["신고"])),
+                        .just(.setReviewData(reviewData)),
                         .just(.setisHiddenOptionView(false)),
                         .just(.setType(type))
                     ])
@@ -152,6 +171,9 @@ final class OptionReactor: Reactor {
             
         case .setPostData(let data):
             state.postData = data
+            
+        case .setReviewData(let data):
+            state.reviewData = data
             
         case .setType(let type):
             state.type = type

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/Reactor/OptionReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/Reactor/OptionReactor.swift
@@ -133,7 +133,6 @@ final class OptionReactor: Reactor {
                 case .Post(_):
                     return deletePost()
                 case .Review(_):
-                    // TODO: API 연동 후 아래 실행
                     return .concat([
                         .just(.setisHiddenOptionView(true)),
                         .just(.setIsTapDelete(true)),

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/View/OptionView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/HPedia/Option/View/OptionView.swift
@@ -230,6 +230,18 @@ class OptionView: UIView, View {
                             reactor.action.onNext(.didTapOkReportAlert)
                         })
                     }
+                    
+                case .Review(_):
+                    if let parentVC = owner.parentVC {
+                        parentVC.showAlert(
+                            title: "신고",
+                            message: "해당 후기를 신고하시겠습니까?",
+                            buttonTitle1: "아니요",
+                            buttonTitle2: "네",
+                            action2: {
+                            reactor.action.onNext(.didTapOkReportAlert)
+                        })
+                    }
                 default:
                     break
                 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/Common/View/HBTIReviewView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/Common/View/HBTIReviewView.swift
@@ -56,7 +56,7 @@ final class HBTIReviewView: UIView {
         $0.setTextWithLineHeight(text: "시향카드", lineHeight: 17)
     }
     
-    private let optionButton = UIButton().then {
+    let optionButton = UIButton().then {
         let image = UIImage(named: "verticalOption")
         $0.setImage(image, for: .normal)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
@@ -14,8 +14,9 @@ final class HBTIReactor: Reactor {
         case didTapSurveyCell(Int)
         case didTapSeeAllReviewButton
         case didTapLikeButton(Int)
-        case didTapOptionButton(Int)
+        case didTapOptionButton(HBTIReview?)
         case didTapDeleteReview
+        case didTapEditReview
     }
     
     enum Mutation {
@@ -25,8 +26,8 @@ final class HBTIReactor: Reactor {
         case setIsPushAllReviewList(Bool)
         case setReviewLike(Int)
         case cancelReviewLike(Int)
-        case setIsReviewDeleted
-        case setSelectedReviewIndex(Int?)
+        case setSelectedReview(HBTIReview?)
+        case setIsEditReview(Bool)
     }
     
     struct State {
@@ -34,7 +35,8 @@ final class HBTIReactor: Reactor {
         var isPushPerfumeSurvey: Bool = false
         var isPushAllReviewList: Bool = false
         var topReviewList: [HBTIHomeItem] = []
-        var selectedReviewIndex: Int? = nil
+        var selectedReview: HBTIReview? = nil
+        var isEditReivew: Bool = false
     }
     
     var initialState: State
@@ -70,15 +72,21 @@ final class HBTIReactor: Reactor {
         case .didTapLikeButton(let index):
             return setReviewLike(index: index)
             
-        case .didTapOptionButton(let row):
+        case .didTapOptionButton(let review):
             return .concat([
-                .just(.setSelectedReviewIndex(row))
+                .just(.setSelectedReview(review))
             ])
             
         case .didTapDeleteReview:
             return .concat([
                 deleteSelectedReview(),
-                .just(.setSelectedReviewIndex(nil))
+                .just(.setSelectedReview(nil))
+            ])
+            
+        case .didTapEditReview:
+            return .concat([
+                .just(.setIsEditReview(true)),
+                .just(.setIsEditReview(false))
             ])
         }
     }
@@ -111,11 +119,11 @@ final class HBTIReactor: Reactor {
             review.likeCount -= 1
             state.topReviewList[index] = HBTIHomeItem.review(review)
             
-        case .setSelectedReviewIndex(let index):
-            state.selectedReviewIndex = index
+        case .setSelectedReview(let review):
+            state.selectedReview = review
             
-        case .setIsReviewDeleted:
-            let selectedReviewIndex = state.selectedReviewIndex
+        case .setIsEditReview(let isEdit):
+            state.isEditReivew = isEdit
         }
         
         return state
@@ -160,12 +168,12 @@ extension HBTIReactor {
     }
     
     func deleteSelectedReview() -> Observable<Mutation> {
-        guard let index = currentState.selectedReviewIndex else { return .empty() }
+        guard let review = currentState.selectedReview else { return .empty() }
         var reviewList = currentState.topReviewList
-        let id = reviewList[index].review!.id
+        let index = reviewList.firstIndex(of: .review(review))!
         reviewList.remove(at: index)
         
-        return HBTIAPI.deleteReivew(id: id)
+        return HBTIAPI.deleteReivew(id: review.id)
             .catch { _ in .empty() }
             .flatMap { _ -> Observable<Mutation> in
                 return .just(.setTopReviewList(reviewList))

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
@@ -76,7 +76,10 @@ final class HBTIReactor: Reactor {
             ])
             
         case .didTapDeleteReview:
-            return .just(.setIsReviewDeleted)
+            return .concat([
+                deleteSelectedReview(),
+                .just(.setSelectedReviewIndex(nil))
+            ])
         }
     }
     
@@ -113,7 +116,6 @@ final class HBTIReactor: Reactor {
             
         case .setIsReviewDeleted:
             let selectedReviewIndex = state.selectedReviewIndex
-            print(selectedReviewIndex)
         }
         
         return state
@@ -155,5 +157,18 @@ extension HBTIReactor {
                     ])
                 }
         }
+    }
+    
+    func deleteSelectedReview() -> Observable<Mutation> {
+        guard let index = currentState.selectedReviewIndex else { return .empty() }
+        var reviewList = currentState.topReviewList
+        let id = reviewList[index].review!.id
+        reviewList.remove(at: index)
+        
+        return HBTIAPI.deleteReivew(id: id)
+            .catch { _ in .empty() }
+            .flatMap { _ -> Observable<Mutation> in
+                return .just(.setTopReviewList(reviewList))
+            }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
@@ -21,6 +21,7 @@ final class HBTIReactor: Reactor {
     
     enum Mutation {
         case setIsOrdered(Bool)
+        case setBackgroundImageURL(String?)
         case setTopReviewList([HBTIHomeItem])
         case setIsPushNoteSurvey(Bool)
         case setIsPushPerfumeSurvey(Bool)
@@ -33,6 +34,7 @@ final class HBTIReactor: Reactor {
     
     struct State {
         var isOrdered: Bool = false
+        var backgroundImageURL: String? = nil
         var isPushNoteSurvey: Bool = false
         var isPushPerfumeSurvey: Bool = false
         var isPushAllReviewList: Bool = false
@@ -50,7 +52,10 @@ final class HBTIReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewWillAppear:
-            return setTopReviewList()
+            return .concat([
+                setHomeInfo(),
+                setTopReviewList()
+            ])
             
         case .didTapSurveyCell(let row):
             if row == 0 {
@@ -100,6 +105,9 @@ final class HBTIReactor: Reactor {
         case .setIsOrdered(let isOrdered):
             state.isOrdered = isOrdered
             
+        case .setBackgroundImageURL(let url):
+            state.backgroundImageURL = url
+            
         case .setTopReviewList(let item):
             state.topReviewList = item
             
@@ -140,7 +148,10 @@ extension HBTIReactor {
         return HBTIAPI.fetchHomeInfo()
             .catch { _ in .empty() }
             .flatMap { infoData -> Observable<Mutation> in
-                return .just(.setIsOrdered(infoData.isOrdered))
+                return .concat([
+                    .just(.setIsOrdered(infoData.isOrdered)),
+                    .just(.setBackgroundImageURL(infoData.backgroundImageURL))
+                ])
             }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
@@ -14,6 +14,8 @@ final class HBTIReactor: Reactor {
         case didTapSurveyCell(Int)
         case didTapSeeAllReviewButton
         case didTapLikeButton(Int)
+        case didTapOptionButton(Int)
+        case didTapDeleteReview
     }
     
     enum Mutation {
@@ -23,6 +25,8 @@ final class HBTIReactor: Reactor {
         case setIsPushAllReviewList(Bool)
         case setReviewLike(Int)
         case cancelReviewLike(Int)
+        case setIsReviewDeleted
+        case setSelectedReviewIndex(Int?)
     }
     
     struct State {
@@ -30,6 +34,7 @@ final class HBTIReactor: Reactor {
         var isPushPerfumeSurvey: Bool = false
         var isPushAllReviewList: Bool = false
         var topReviewList: [HBTIHomeItem] = []
+        var selectedReviewIndex: Int? = nil
     }
     
     var initialState: State
@@ -64,6 +69,14 @@ final class HBTIReactor: Reactor {
             
         case .didTapLikeButton(let index):
             return setReviewLike(index: index)
+            
+        case .didTapOptionButton(let row):
+            return .concat([
+                .just(.setSelectedReviewIndex(row))
+            ])
+            
+        case .didTapDeleteReview:
+            return .just(.setIsReviewDeleted)
         }
     }
     
@@ -94,6 +107,13 @@ final class HBTIReactor: Reactor {
             review.isLiked = false
             review.likeCount -= 1
             state.topReviewList[index] = HBTIHomeItem.review(review)
+            
+        case .setSelectedReviewIndex(let index):
+            state.selectedReviewIndex = index
+            
+        case .setIsReviewDeleted:
+            let selectedReviewIndex = state.selectedReviewIndex
+            print(selectedReviewIndex)
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/Reactor/HBTIReactor.swift
@@ -20,6 +20,7 @@ final class HBTIReactor: Reactor {
     }
     
     enum Mutation {
+        case setIsOrdered(Bool)
         case setTopReviewList([HBTIHomeItem])
         case setIsPushNoteSurvey(Bool)
         case setIsPushPerfumeSurvey(Bool)
@@ -31,6 +32,7 @@ final class HBTIReactor: Reactor {
     }
     
     struct State {
+        var isOrdered: Bool = false
         var isPushNoteSurvey: Bool = false
         var isPushPerfumeSurvey: Bool = false
         var isPushAllReviewList: Bool = false
@@ -95,6 +97,9 @@ final class HBTIReactor: Reactor {
         var state = state
         
         switch mutation {
+        case .setIsOrdered(let isOrdered):
+            state.isOrdered = isOrdered
+            
         case .setTopReviewList(let item):
             state.topReviewList = item
             
@@ -131,6 +136,14 @@ final class HBTIReactor: Reactor {
 }
 
 extension HBTIReactor {
+    func setHomeInfo() -> Observable<Mutation> {
+        return HBTIAPI.fetchHomeInfo()
+            .catch { _ in .empty() }
+            .flatMap { infoData -> Observable<Mutation> in
+                return .just(.setIsOrdered(infoData.isOrdered))
+            }
+    }
+    
     func setTopReviewList() -> Observable<Mutation> {
         return HBTIAPI.fetchReivewList(fromMember: false, page: 0)
             .catch { _ in .empty() }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -80,18 +80,19 @@ final class HBTIViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        //
-        hbtiHomeCollectionView.rx.itemSelected
-            .filter { $0.section == 1 }
-            .map { Reactor.Action.didTapOptionButton($0.row) }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
         optionView.reactor?.state
             .map { $0.isTapDelete }
             .distinctUntilChanged()
             .filter { $0 }
             .map { _ in Reactor.Action.didTapDeleteReview }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        optionView.reactor?.state
+            .map { $0.isTapEdit }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in Reactor.Action.didTapEditReview }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
@@ -128,6 +129,17 @@ final class HBTIViewController: UIViewController, View {
             .drive(with: self, onNext: { owner, _ in
                 owner.presentHBTIReviewListViewController(isLog: false)
             })
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isEditReivew }
+            .filter { $0 }
+            .map { _ in }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self) { owner, isPush in
+                guard let review = reactor.currentState.selectedReview else { return }
+                owner.presentHBTIReviewWriteViewController(reviewID: review.id, content: review.content, communityPhotos: review.photoList)
+            }
             .disposed(by: disposeBag)
     }
     
@@ -272,7 +284,7 @@ final class HBTIViewController: UIViewController, View {
                 
                 cell.reviewView.optionButton.rx.tap
                     .bind(with: self, onNext: { owner, _  in
-                        let detailAction = HBTIReactor.Action.didTapOptionButton(indexPath.row)
+                        let detailAction = HBTIReactor.Action.didTapOptionButton(review)
                         owner.reactor?.action.onNext(detailAction)
                     })
                     .disposed(by: cell.disposeBag)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -13,6 +13,7 @@ import RxCocoa
 import RxSwift
 import SnapKit
 import Then
+import Kingfisher
 
 final class HBTIViewController: UIViewController, View {
     
@@ -22,6 +23,10 @@ final class HBTIViewController: UIViewController, View {
     }
     
     // MARK: - UI Components
+    
+    private lazy var backgroundImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+    }
     
     private lazy var hbtiHomeCollectionView = UICollectionView(
         frame: .zero,
@@ -98,6 +103,14 @@ final class HBTIViewController: UIViewController, View {
         
         // MARK: State
         reactor.state
+            .compactMap { $0.backgroundImageURL }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, url in
+                owner.backgroundImageView.kf.setImage(with: URL(string: url))
+            })
+            .disposed(by: disposeBag)
+        
+        reactor.state
             .map { $0.topReviewList }
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, item in
@@ -157,6 +170,7 @@ final class HBTIViewController: UIViewController, View {
     // MARK: Add Views
     private func setAddView() {
         [
+            backgroundImageView,
             hbtiHomeCollectionView,
             optionView
         ].forEach { view.addSubview($0) }
@@ -164,6 +178,10 @@ final class HBTIViewController: UIViewController, View {
     
     // MARK: Set Constraints
     private func setConstraints() {
+        backgroundImageView.snp.makeConstraints { make in
+            make.edges.equalTo(hbtiHomeCollectionView.snp.edges)
+        }
+        
         hbtiHomeCollectionView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             make.horizontalEdges.bottom.equalToSuperview()

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -238,10 +238,10 @@ final class HBTIViewController: UIViewController, View {
                     .disposed(by: cell.disposeBag)
                 
                 self.reactor!.state
-                    .map { $0.topReviewList[indexPath.row] }
+                    .map { $0.topReviewList.first(where: { $0.review?.id == review.id }) }
                     .asDriver(onErrorRecover: { _ in .empty() })
                     .drive(with: self, onNext: { owner, item in
-                        guard let review = item.review else { return }
+                        guard let review = item?.review else { return }
                         cell.reviewView.heartButton.isSelected = review.isLiked
                         cell.reviewView.likeCountLabel.text = String(review.likeCount)
                     })
@@ -269,6 +269,13 @@ final class HBTIViewController: UIViewController, View {
                 let optionReviewData = OptionReviewData(id: review.id,
                                                         content: review.content,
                                                         isWrited: review.isWrited)
+                
+                cell.reviewView.optionButton.rx.tap
+                    .bind(with: self, onNext: { owner, _  in
+                        let detailAction = HBTIReactor.Action.didTapOptionButton(indexPath.row)
+                        owner.reactor?.action.onNext(detailAction)
+                    })
+                    .disposed(by: cell.disposeBag)
                 
                 cell.reviewView.optionButton.rx.tap
                     .map { OptionReactor.Action.didTapOptionButton(.Review(optionReviewData)) }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -35,6 +35,10 @@ final class HBTIViewController: UIViewController, View {
         $0.register(HBTIHomeReviewHeaderView.self, forSupplementaryViewOfKind: SupplementaryViewKind.review.rawValue, withReuseIdentifier: HBTIHomeReviewHeaderView.identifier)
     }
     
+    private lazy var optionView = OptionView().then {
+        $0.reactor = OptionReactor()
+    }
+    
     // MARK: - Properties
     
     private var sections = [HBTIHomeSection]()
@@ -73,6 +77,21 @@ final class HBTIViewController: UIViewController, View {
         hbtiHomeCollectionView.rx.itemSelected
             .filter { $0.section == 0 }
             .map { Reactor.Action.didTapSurveyCell($0.row) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        //
+        hbtiHomeCollectionView.rx.itemSelected
+            .filter { $0.section == 1 }
+            .map { Reactor.Action.didTapOptionButton($0.row) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        optionView.reactor?.state
+            .map { $0.isTapDelete }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in Reactor.Action.didTapDeleteReview }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
@@ -117,7 +136,8 @@ final class HBTIViewController: UIViewController, View {
     // MARK: Add Views
     private func setAddView() {
         [
-            hbtiHomeCollectionView
+            hbtiHomeCollectionView,
+            optionView
         ].forEach { view.addSubview($0) }
     }
     
@@ -126,6 +146,10 @@ final class HBTIViewController: UIViewController, View {
         hbtiHomeCollectionView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             make.horizontalEdges.bottom.equalToSuperview()
+        }
+        
+        optionView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
     }
     
@@ -239,6 +263,17 @@ final class HBTIViewController: UIViewController, View {
                         owner.presentImageListVC(indexPath, images: item.review!.photoList)
                     })
                     .disposed(by: cell.disposeBag)
+                
+                self.optionView.parentVC = self
+                
+                let optionReviewData = OptionReviewData(id: review.id,
+                                                        content: review.content,
+                                                        isWrited: review.isWrited)
+                
+                cell.reviewView.optionButton.rx.tap
+                    .map { OptionReactor.Action.didTapOptionButton(.Review(optionReviewData)) }
+                    .bind(to: self.optionView.reactor!.action)
+                    .disposed(by: self.disposeBag)
                 
                 return cell
             }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -116,9 +116,18 @@ final class HBTIViewController: UIViewController, View {
         reactor.state
             .map { $0.isPushPerfumeSurvey }
             .filter { $0 }
-            .map { _ in }
             .asDriver(onErrorRecover: { _ in return .empty() })
-            .drive(onNext: presentHBTIPerfumeSurveyViewController)
+            .drive(with: self, onNext: { owner, _ in
+                let isOrdered = reactor.currentState.isOrdered
+                if isOrdered {
+                    owner.presentHBTIPerfumeSurveyViewController()
+                } else {
+                    owner.presentAlertVC(title: "주문 후 이용가능한 서비스입니다",
+                                         content: "향료 주문 후 이용해주세요",
+                                         buttonTitle: "확인",
+                                         type: .order)
+                }
+            })
             .disposed(by: disposeBag)
         
         reactor.state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/Reactor/HBTIReviewListReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/Reactor/HBTIReviewListReactor.swift
@@ -12,6 +12,7 @@ final class HBTIReviewListReactor: Reactor {
     
     enum Action {
         case viewWillAppear
+        case viewDidAppear
         case loadReviewListNextPage
         case didTapLikeButton(Int)
         case didTapFloatingButton
@@ -21,6 +22,7 @@ final class HBTIReviewListReactor: Reactor {
     
     enum Mutation {
         case setReviewList([HBTIReviewListItem])
+        case appendReviewList([HBTIReviewListItem])
         case setIsLastPage(Bool)
         case setCurrentPage(Int)
         case setReviewLike(Int)
@@ -37,10 +39,7 @@ final class HBTIReviewListReactor: Reactor {
         var currentPage: Int = -1
         var isLastPage: Bool = false
         var isFloatingButtonTap: Bool = false
-        var notReviewedOrderList: [NotReviewedOrder] = [
-            NotReviewedOrder(id: 11, info: "후기 작성하기 (시트러스 24.10.08)"),
-            NotReviewedOrder(id: 33, info: "후기 작성하기 (플로럴 24.10.08)")
-        ]
+        var notReviewedOrderList: [NotReviewedOrder] = []
         var selectedOrderID: Int? = nil
         var isPushReviewWriteVC: Bool = false
     }
@@ -55,9 +54,14 @@ final class HBTIReviewListReactor: Reactor {
         switch action {
         case .viewWillAppear:
             return .concat([
+                .just(.setCurrentPage(-1)),
+                .just(.setIsLastPage(false))
+            ])
+            
+        case .viewDidAppear:
+            return .concat([
                 setReviewList(),
-                // TODO: 주문 추가 가능해지면 사용
-//                setNotReviewedOrderList()
+                setNotReviewedOrderList()
             ])
             
         case .loadReviewListNextPage:
@@ -77,8 +81,7 @@ final class HBTIReviewListReactor: Reactor {
                 .just(.setIsTapFloatingButton(!currentState.isFloatingButtonTap)),
                 .just(.setSelectedOrderID(id)),
                 .just(.setIsPushReviewWriteVC(true)),
-                .just(.setSelectedOrderID(nil)),
-                .just(.setIsPushReviewWriteVC(false))
+                .just(.setSelectedOrderID(nil))
             ])
         }
     }
@@ -88,6 +91,9 @@ final class HBTIReviewListReactor: Reactor {
         
         switch mutation {
         case .setReviewList(let item):
+            state.reviewList = item
+            
+        case .appendReviewList(let item):
             state.reviewList += item
             
         case .setIsLastPage(let isLast):
@@ -139,11 +145,20 @@ extension HBTIReviewListReactor {
                 }
                 let isLastPage = reviewListData.isLastPage
                 
-                return .concat([
-                    .just(.setReviewList(listData)),
-                    .just(.setIsLastPage(isLastPage)),
-                    .just(.setCurrentPage(nextPage))
-                ])
+                if self.currentState.isPushReviewWriteVC {
+                    return .concat([
+                        .just(.setIsPushReviewWriteVC(false)),
+                        .just(.setReviewList(listData)),
+                        .just(.setIsLastPage(isLastPage)),
+                        .just(.setCurrentPage(nextPage))
+                    ])
+                } else {
+                    return .concat([
+                        .just(.appendReviewList(listData)),
+                        .just(.setIsLastPage(isLastPage)),
+                        .just(.setCurrentPage(nextPage))
+                    ])
+                }
             }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/Reactor/HBTIReviewListReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/Reactor/HBTIReviewListReactor.swift
@@ -99,7 +99,8 @@ final class HBTIReviewListReactor: Reactor {
         case .didTapDeleteReview:
             return .concat([
                 deleteSelectedReview(),
-                .just(.setSelectedReview(nil))
+                .just(.setSelectedReview(nil)),
+                setNotReviewedOrderList()
             ])
             
         case .didTapEditReview:

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/Reactor/HBTIReviewListReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/Reactor/HBTIReviewListReactor.swift
@@ -18,8 +18,9 @@ final class HBTIReviewListReactor: Reactor {
         case didTapFloatingButton
         case didTapFloatingBackView
         case didTapWriteReviewButton(Int)
-        case didTapOptionButton(Int)
+        case didTapOptionButton(HBTIReview?)
         case didTapDeleteReview
+        case didTapEditReview
     }
     
     enum Mutation {
@@ -33,7 +34,8 @@ final class HBTIReviewListReactor: Reactor {
         case setNotReviewedOrderList([NotReviewedOrder])
         case setSelectedOrderID(Int?)
         case setIsPushReviewWriteVC(Bool)
-        case setSelectedReviewIndex(Int?)
+        case setSelectedReview(HBTIReview?)
+        case setIsEditReview(Bool)
     }
     
     struct State {
@@ -45,7 +47,8 @@ final class HBTIReviewListReactor: Reactor {
         var notReviewedOrderList: [NotReviewedOrder] = []
         var selectedOrderID: Int? = nil
         var isPushReviewWriteVC: Bool = false
-        var selectedReviewIndex: Int? = nil
+        var selectedReview: HBTIReview? = nil
+        var isEditReivew: Bool = false
     }
     
     var initialState: State
@@ -88,15 +91,21 @@ final class HBTIReviewListReactor: Reactor {
                 .just(.setSelectedOrderID(nil))
             ])
             
-        case .didTapOptionButton(let row):
+        case .didTapOptionButton(let review):
             return .concat([
-                .just(.setSelectedReviewIndex(row))
+                .just(.setSelectedReview(review))
             ])
             
         case .didTapDeleteReview:
             return .concat([
                 deleteSelectedReview(),
-                .just(.setSelectedReviewIndex(nil))
+                .just(.setSelectedReview(nil))
+            ])
+            
+        case .didTapEditReview:
+            return .concat([
+                .just(.setIsEditReview(true)),
+                .just(.setIsEditReview(false))
             ])
         }
     }
@@ -141,8 +150,11 @@ final class HBTIReviewListReactor: Reactor {
         case .setIsPushReviewWriteVC(let isPush):
             state.isPushReviewWriteVC = isPush
             
-        case .setSelectedReviewIndex(let index):
-            state.selectedReviewIndex = index
+        case .setSelectedReview(let review):
+            state.selectedReview = review
+            
+        case .setIsEditReview(let isEdit):
+            state.isEditReivew = isEdit
         }
         
         return state
@@ -163,7 +175,7 @@ extension HBTIReviewListReactor {
                 }
                 let isLastPage = reviewListData.isLastPage
                 
-                if self.currentState.isPushReviewWriteVC {
+                if self.currentState.isPushReviewWriteVC || !self.currentState.isLastPage {
                     return .concat([
                         .just(.setIsPushReviewWriteVC(false)),
                         .just(.setReviewList(listData)),
@@ -211,12 +223,12 @@ extension HBTIReviewListReactor {
     }
     
     func deleteSelectedReview() -> Observable<Mutation> {
-        guard let index = currentState.selectedReviewIndex else { return .empty() }
+        guard let review = currentState.selectedReview else { return .empty() }
         var reviewList = currentState.reviewList
-        let id = reviewList[index].review!.id
+        let index = reviewList.firstIndex(of: .review(review))!
         reviewList.remove(at: index)
         
-        return HBTIAPI.deleteReivew(id: id)
+        return HBTIAPI.deleteReivew(id: review.id)
             .catch { _ in .empty() }
             .flatMap { _ -> Observable<Mutation> in
                 return .just(.setReviewList(reviewList))

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/Reactor/HBTIReviewListReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/Reactor/HBTIReviewListReactor.swift
@@ -33,7 +33,6 @@ final class HBTIReviewListReactor: Reactor {
         case setNotReviewedOrderList([NotReviewedOrder])
         case setSelectedOrderID(Int?)
         case setIsPushReviewWriteVC(Bool)
-        case setIsReviewDeleted
         case setSelectedReviewIndex(Int?)
     }
     
@@ -95,7 +94,10 @@ final class HBTIReviewListReactor: Reactor {
             ])
             
         case .didTapDeleteReview:
-            return .just(.setIsReviewDeleted)
+            return .concat([
+                deleteSelectedReview(),
+                .just(.setSelectedReviewIndex(nil))
+            ])
         }
     }
     
@@ -141,10 +143,6 @@ final class HBTIReviewListReactor: Reactor {
             
         case .setSelectedReviewIndex(let index):
             state.selectedReviewIndex = index
-            
-        case .setIsReviewDeleted:
-            let selectedReviewIndex = state.selectedReviewIndex
-            print(selectedReviewIndex)
         }
         
         return state
@@ -209,6 +207,19 @@ extension HBTIReviewListReactor {
             .catch { _ in .empty() }
             .flatMap { orderListData -> Observable<Mutation> in
                 return .just(.setNotReviewedOrderList(orderListData))
+            }
+    }
+    
+    func deleteSelectedReview() -> Observable<Mutation> {
+        guard let index = currentState.selectedReviewIndex else { return .empty() }
+        var reviewList = currentState.reviewList
+        let id = reviewList[index].review!.id
+        reviewList.remove(at: index)
+        
+        return HBTIAPI.deleteReivew(id: id)
+            .catch { _ in .empty() }
+            .flatMap { _ -> Observable<Mutation> in
+                return .just(.setReviewList(reviewList))
             }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/Reactor/HBTIReviewListReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/Reactor/HBTIReviewListReactor.swift
@@ -18,6 +18,8 @@ final class HBTIReviewListReactor: Reactor {
         case didTapFloatingButton
         case didTapFloatingBackView
         case didTapWriteReviewButton(Int)
+        case didTapOptionButton(Int)
+        case didTapDeleteReview
     }
     
     enum Mutation {
@@ -31,6 +33,8 @@ final class HBTIReviewListReactor: Reactor {
         case setNotReviewedOrderList([NotReviewedOrder])
         case setSelectedOrderID(Int?)
         case setIsPushReviewWriteVC(Bool)
+        case setIsReviewDeleted
+        case setSelectedReviewIndex(Int?)
     }
     
     struct State {
@@ -42,6 +46,7 @@ final class HBTIReviewListReactor: Reactor {
         var notReviewedOrderList: [NotReviewedOrder] = []
         var selectedOrderID: Int? = nil
         var isPushReviewWriteVC: Bool = false
+        var selectedReviewIndex: Int? = nil
     }
     
     var initialState: State
@@ -83,6 +88,14 @@ final class HBTIReviewListReactor: Reactor {
                 .just(.setIsPushReviewWriteVC(true)),
                 .just(.setSelectedOrderID(nil))
             ])
+            
+        case .didTapOptionButton(let row):
+            return .concat([
+                .just(.setSelectedReviewIndex(row))
+            ])
+            
+        case .didTapDeleteReview:
+            return .just(.setIsReviewDeleted)
         }
     }
     
@@ -125,6 +138,13 @@ final class HBTIReviewListReactor: Reactor {
             
         case .setIsPushReviewWriteVC(let isPush):
             state.isPushReviewWriteVC = isPush
+            
+        case .setSelectedReviewIndex(let index):
+            state.selectedReviewIndex = index
+            
+        case .setIsReviewDeleted:
+            let selectedReviewIndex = state.selectedReviewIndex
+            print(selectedReviewIndex)
         }
         
         return state

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
@@ -151,11 +151,6 @@ final class HBTIReviewListViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        hbtiReviewListCollectionView.rx.itemSelected
-            .map { Reactor.Action.didTapOptionButton($0.row) }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
         optionView.reactor?.state
             .map { $0.isTapDelete }
             .distinctUntilChanged()
@@ -288,10 +283,10 @@ final class HBTIReviewListViewController: UIViewController, View {
                     .disposed(by: cell.disposeBag)
                 
                 self.reactor!.state
-                    .map { $0.reviewList[indexPath.row] }
+                    .map { $0.reviewList.first(where: { $0.review?.id == review.id }) }
                     .asDriver(onErrorRecover: { _ in .empty() })
                     .drive(with: self, onNext: { owner, item in
-                        guard let review = item.review else { return }
+                        guard let review = item?.review else { return }
                         cell.reviewView.heartButton.isSelected = review.isLiked
                         cell.reviewView.likeCountLabel.text = String(review.likeCount)
                     })
@@ -320,6 +315,13 @@ final class HBTIReviewListViewController: UIViewController, View {
                 let optionReviewData = OptionReviewData(id: review.id,
                                                         content: review.content,
                                                         isWrited: review.isWrited)
+                
+                cell.reviewView.optionButton.rx.tap
+                    .bind(with: self, onNext: { owner, _  in
+                        let detailAction = HBTIReviewListReactor.Action.didTapOptionButton(indexPath.row)
+                        owner.reactor?.action.onNext(detailAction)
+                    })
+                    .disposed(by: cell.disposeBag)
                 
                 cell.reviewView.optionButton.rx.tap
                     .map { OptionReactor.Action.didTapOptionButton(.Review(optionReviewData)) }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
@@ -119,6 +119,11 @@ final class HBTIReviewListViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        rx.viewDidAppear
+            .map { _ in Reactor.Action.viewDidAppear }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // 리뷰 마지막 아이템이 나타나면 다음 페이지 로드
         hbtiReviewListCollectionView.rx.willDisplayCell
             .filter { cellInfo in

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
@@ -49,6 +49,10 @@ final class HBTIReviewListViewController: UIViewController, View {
         $0.isHidden = true
     }
     
+    private lazy var optionView = OptionView().then {
+        $0.reactor = OptionReactor()
+    }
+    
     // MARK: - Properties
     
     private var dataSource: UICollectionViewDiffableDataSource<HBTIReviewListSection, HBTIReviewListItem>?
@@ -208,7 +212,8 @@ final class HBTIReviewListViewController: UIViewController, View {
     private func setAddView() {
         
         [
-            hbtiReviewListCollectionView
+            hbtiReviewListCollectionView,
+            optionView
         ].forEach { view.addSubview($0) }
         
     }
@@ -218,6 +223,10 @@ final class HBTIReviewListViewController: UIViewController, View {
         hbtiReviewListCollectionView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             make.horizontalEdges.bottom.equalToSuperview()
+        }
+        
+        optionView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
     }
     
@@ -291,6 +300,19 @@ final class HBTIReviewListViewController: UIViewController, View {
                         owner.presentImageListVC(indexPath, images: item.review!.photoList)
                     })
                     .disposed(by: cell.disposeBag)
+                
+                // 옵션 버튼
+                self.optionView.parentVC = self
+            
+                // TODO: 실제 데이터로 변경
+                let optionReviewData = OptionReviewData(id: review.id,
+                                                        content: review.content,
+                                                        isWrited: review.isWrited)
+                
+                cell.reviewView.optionButton.rx.tap
+                    .map { OptionReactor.Action.didTapOptionButton(.Review(optionReviewData)) }
+                    .bind(to: self.optionView.reactor!.action)
+                    .disposed(by: self.disposeBag)
                 
                 return cell
             }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
@@ -181,11 +181,19 @@ final class HBTIReviewListViewController: UIViewController, View {
             .skip(1)
             .asDriver(onErrorRecover: { _ in return .empty() })
             .drive(with: self, onNext: { owner, isTap in
-                owner.showFloatingButtonAnimation(
-                    floatingButton: owner.floatingButton,
-                    stackView: owner.floatingStackView,
-                    backgroundView: owner.floatingView,
-                    isTap: isTap)
+                let orderList = reactor.currentState.notReviewedOrderList
+                if orderList.isEmpty && isTap {
+                    owner.presentAlertVC(title: "주문 후 이용가능한 서비스입니다",
+                                         content: "배송 후 후기를 작성해주세요",
+                                         buttonTitle: "확인",
+                                         type: .order)
+                } else {
+                    owner.showFloatingButtonAnimation(
+                        floatingButton: owner.floatingButton,
+                        stackView: owner.floatingStackView,
+                        backgroundView: owner.floatingView,
+                        isTap: isTap)
+                }
             })
             .disposed(by: disposeBag)
         

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
@@ -151,6 +151,19 @@ final class HBTIReviewListViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        hbtiReviewListCollectionView.rx.itemSelected
+            .map { Reactor.Action.didTapOptionButton($0.row) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        optionView.reactor?.state
+            .map { $0.isTapDelete }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in Reactor.Action.didTapDeleteReview }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: State
         reactor.state
             .map { $0.reviewList }
@@ -301,10 +314,9 @@ final class HBTIReviewListViewController: UIViewController, View {
                     })
                     .disposed(by: cell.disposeBag)
                 
-                // 옵션 버튼
+                // 옵션 뷰
                 self.optionView.parentVC = self
-            
-                // TODO: 실제 데이터로 변경
+                
                 let optionReviewData = OptionReviewData(id: review.id,
                                                         content: review.content,
                                                         isWrited: review.isWrited)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
@@ -18,10 +18,16 @@ final class HBTIReviewListViewController: UIViewController, View {
     
     // MARK: - UI Components
     
+    // MyLog용 빈 화면
+    private var noItemView = IconMessageView(title: "작성한 후기가 없습니다", iconWidth: 110).then {
+        $0.isHidden = true
+    }
+    
     private lazy var hbtiReviewListCollectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: createLayout()
     ).then {
+        $0.isHidden = true
         $0.register(HBTIReviewCell.self, forCellWithReuseIdentifier: HBTIReviewCell.identifier)
     }
     
@@ -172,6 +178,9 @@ final class HBTIReviewListViewController: UIViewController, View {
             .map { $0.reviewList }
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, item in
+                if reactor.currentState.isLog {
+                    owner.updateCollectionViewIsHidden(isHidden: item.isEmpty)
+                }
                 owner.updateSnapshot(forSection: .review, withItem: item)
             })
             .disposed(by: disposeBag)
@@ -248,7 +257,8 @@ final class HBTIReviewListViewController: UIViewController, View {
         
         [
             hbtiReviewListCollectionView,
-            optionView
+            optionView,
+            noItemView
         ].forEach { view.addSubview($0) }
         
     }
@@ -262,6 +272,10 @@ final class HBTIReviewListViewController: UIViewController, View {
         
         optionView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+        
+        noItemView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
         }
     }
     
@@ -375,5 +389,12 @@ final class HBTIReviewListViewController: UIViewController, View {
         snapshot.appendItems(item, toSection: section)
         
         dataSource.apply(snapshot, animatingDifferences: false)
+    }
+}
+
+extension HBTIReviewListViewController {
+    private func updateCollectionViewIsHidden(isHidden: Bool) {
+        noItemView.isHidden = !isHidden
+        hbtiReviewListCollectionView.isHidden = isHidden
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
@@ -159,6 +159,14 @@ final class HBTIReviewListViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        optionView.reactor?.state
+            .map { $0.isTapEdit }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in Reactor.Action.didTapEditReview }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         // MARK: State
         reactor.state
             .map { $0.reviewList }
@@ -206,6 +214,17 @@ final class HBTIReviewListViewController: UIViewController, View {
                 guard let orderID = reactor.currentState.selectedOrderID else { return }
                 owner.presentHBTIReviewWriteViewController(orderID: orderID)
             })
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isEditReivew }
+            .filter { $0 }
+            .map { _ in }
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self) { owner, isPush in
+                guard let review = reactor.currentState.selectedReview else { return }
+                owner.presentHBTIReviewWriteViewController(reviewID: review.id, content: review.content, communityPhotos: review.photoList)
+            }
             .disposed(by: disposeBag)
     }
     
@@ -318,7 +337,7 @@ final class HBTIReviewListViewController: UIViewController, View {
                 
                 cell.reviewView.optionButton.rx.tap
                     .bind(with: self, onNext: { owner, _  in
-                        let detailAction = HBTIReviewListReactor.Action.didTapOptionButton(indexPath.row)
+                        let detailAction = HBTIReviewListReactor.Action.didTapOptionButton(review)
                         owner.reactor?.action.onNext(detailAction)
                     })
                     .disposed(by: cell.disposeBag)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewWrite/Reactor/HBTIReviewWriteReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewWrite/Reactor/HBTIReviewWriteReactor.swift
@@ -10,6 +10,7 @@ import RxSwift
 final class HBTIReviewWriteReactor: Reactor {
     
     enum Action {
+        case viewDidLoad
         case didBeginEditing
         case didChangeTextViewEditing(String)
         case didTapAddPhotoButton
@@ -27,28 +28,45 @@ final class HBTIReviewWriteReactor: Reactor {
         case setIsDeletedLast(Bool)
         case setCurrentPage(Int)
         case setSuccess
+        case setEditImages([WritePhoto])
     }
     
     struct State {
-        let id: Int
+        let orderID: Int?
+        let reviewID: Int?
         var content: String = "내용을 입력해주세요"
         var okButtonEnable: Bool = false
         var isPresentToAlbum: Bool = false
         var photoCount: Int = 0
         var images: [WritePhoto] = []
+        var communityPhotos: [CommunityPhoto] = []
         var currentPage: Int = 0
         var deletePhotoIds: [Int] = []
         var isDeletedLast: Bool = false
+        var editImages: [WritePhoto] = []
     }
     
     var initialState: State
     
     init(orderID: Int) {
-        self.initialState = State(id: orderID)
+        self.initialState = State(orderID: orderID, reviewID: nil)
+    }
+    
+    init(reviewID: Int, content: String, photos: [CommunityPhoto]) {
+        self.initialState = State(orderID: nil, reviewID: reviewID, content: content, photoCount: photos.count, communityPhotos: photos)
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .viewDidLoad:
+            return CommunityWriteReactor.loadPhotos(currentState.communityPhotos)
+                .flatMap { photos -> Observable<Mutation> in
+                        .concat([
+                            .just(.setImages(photos)),
+                            .just(.setEditImages(photos))
+                        ])
+                }
+            
         case .didBeginEditing:
             if currentState.content == "내용을 입력해주세요" {
                 return .just(.setContent(""))
@@ -85,7 +103,11 @@ final class HBTIReviewWriteReactor: Reactor {
             } else { return .empty() }
             
         case .didTapOkButton:
-            return postReviewPost()
+            if initialState.orderID != nil {
+                return postReviewPost()
+            } else {
+                return editReview()
+            }
         }
     }
     
@@ -121,6 +143,9 @@ final class HBTIReviewWriteReactor: Reactor {
             
         case .setSuccess:
             break
+            
+        case .setEditImages(let editImages):
+            state.editImages = editImages
         }
         
         return state
@@ -144,11 +169,35 @@ extension HBTIReviewWriteReactor {
         }
         
         let params: [String: Any] = [
-            "orderId": state.id,
+            "orderId": state.orderID!,
             "content": state.content
         ]
         let images = state.images.map { $0.image }
         return HBTIAPI.postReview(params, images: images)
+            .catch { _ in .empty() }
+            .flatMap { data -> Observable<Mutation> in
+                return .just(.setSuccess)
+            }
+    }
+    
+    func editReview() -> Observable<Mutation> {
+        let state = currentState
+        
+        if state.content.isEmpty {
+            return .empty()
+        }
+        var addImages: [UIImage] = []
+        for item in currentState.images {
+            if !currentState.editImages.contains(where: { $0 == item }) {
+                addImages.append(item.image)
+            }
+        }
+        let params: [String: Any] = [
+            "reviewId": state.reviewID!,
+            "content": state.content,
+            "deleteReviewPhotoIds": state.deletePhotoIds
+        ]
+        return HBTIAPI.editReview(reviewID: state.reviewID!,params: params, images: addImages)
             .catch { _ in .empty() }
             .flatMap { data -> Observable<Mutation> in
                 return .just(.setSuccess)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewWrite/Reactor/HBTIReviewWriteReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewWrite/Reactor/HBTIReviewWriteReactor.swift
@@ -144,7 +144,7 @@ extension HBTIReviewWriteReactor {
         }
         
         let params: [String: Any] = [
-            "reviewId": state.id,
+            "orderId": state.id,
             "content": state.content
         ]
         let images = state.images.map { $0.image }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewWrite/ViewController/HBTIReviewWriteViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewWrite/ViewController/HBTIReviewWriteViewController.swift
@@ -135,6 +135,11 @@ final class HBTIReviewWriteViewController: UIViewController, View {
     func bind(reactor: HBTIReviewWriteReactor) {
         
         // MARK: Action
+        Observable.just(())
+            .map { Reactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         addImageButton.rx.tap
             .map { Reactor.Action.didTapAddPhotoButton }
             .bind(to: reactor.action)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/ViewController/OrderCancelLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelLog/ViewController/OrderCancelLogViewController.swift
@@ -16,7 +16,12 @@ import Then
 final class OrderCancelLogViewController: UIViewController, View {
 
     // MARK: - UI Components
+    private var noItemView = IconMessageView(title: "취소/환불 내역이 없습니다", iconWidth: 110).then {
+        $0.isHidden = true
+    }
+    
     private lazy var orderCancelLogTableView = UITableView(frame: .zero, style: .plain).then {
+        $0.isHidden = true
         $0.register(OrderCancelLogCell.self, forCellReuseIdentifier: OrderCancelLogCell.identifier)
     }
 
@@ -60,6 +65,7 @@ final class OrderCancelLogViewController: UIViewController, View {
             .distinctUntilChanged()
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, items in
+                owner.updateTableViewIsHidden(isHidden: items.isEmpty)
                 owner.updateSnapshot(forSection: .cancel, withItems: items)
             })
             .disposed(by: disposeBag)
@@ -76,7 +82,8 @@ final class OrderCancelLogViewController: UIViewController, View {
     // MARK: Add Views
     private func setAddView() {
         [
-            orderCancelLogTableView
+            orderCancelLogTableView,
+            noItemView
         ]   .forEach { view.addSubview($0) }
     }
 
@@ -86,6 +93,10 @@ final class OrderCancelLogViewController: UIViewController, View {
             make.top.equalToSuperview().inset(3)
             make.horizontalEdges.equalToSuperview().inset(16)
             make.bottom.equalToSuperview()
+        }
+        
+        noItemView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
         }
     }
     
@@ -123,4 +134,11 @@ final class OrderCancelLogViewController: UIViewController, View {
         dataSource.apply(snapshot, animatingDifferences: false)
     }
 
+}
+
+extension OrderCancelLogViewController {
+    private func updateTableViewIsHidden(isHidden: Bool) {
+        noItemView.isHidden = !isHidden
+        orderCancelLogTableView.isHidden = isHidden
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
@@ -28,7 +28,7 @@ final class OrderLogReactor: Reactor {
     }
     
     struct State {
-        var orderList: [OrderLogItem] = OrderLogItem.exampleOrder
+        var orderList: [OrderLogItem] = []
         var nextPage: Int = 0
         var selectedOrder: OrderLogItem? = nil
         var isPushRefundVC: Bool = false

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -17,8 +17,13 @@ final class OrderLogViewController: UIViewController, View {
 
     // MARK: - UI Components
     
+    private var noItemView = IconMessageView(title: "주문 내역이 없습니다", iconWidth: 110).then {
+        $0.isHidden = true
+    }
+    
     private lazy var orderCollectionView = UICollectionView(frame: .zero,
                                                             collectionViewLayout: createLayout()).then {
+        $0.isHidden = true
         $0.register(OrderCell.self, forCellWithReuseIdentifier: OrderCell.identifier)
     }
     
@@ -68,6 +73,7 @@ final class OrderLogViewController: UIViewController, View {
             .distinctUntilChanged()
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, items in
+                owner.updateCollectionViewIsHidden(isHidden: items.isEmpty)
                 owner.updateSnapshot(forSection: .order, withItems: items)
             })
             .disposed(by: disposeBag)
@@ -113,7 +119,8 @@ final class OrderLogViewController: UIViewController, View {
     // MARK: Add Views
     private func setAddView() {
         [
-            orderCollectionView
+            orderCollectionView,
+            noItemView
         ]   .forEach { view.addSubview($0) }
     }
     
@@ -121,6 +128,10 @@ final class OrderLogViewController: UIViewController, View {
     private func setConstraints() {
         orderCollectionView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+        
+        noItemView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
         }
     }
     
@@ -191,4 +202,11 @@ final class OrderLogViewController: UIViewController, View {
         dataSource.apply(snapshot, animatingDifferences: false)
     }
 
+}
+
+extension OrderLogViewController {
+    private func updateCollectionViewIsHidden(isHidden: Bool) {
+        noItemView.isHidden = !isHidden
+        orderCollectionView.isHidden = isHidden
+    }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -68,8 +68,6 @@ final class OrderLogViewController: UIViewController, View {
             .distinctUntilChanged()
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, items in
-                print("state")
-                print(items)
                 owner.updateSnapshot(forSection: .order, withItems: items)
             })
             .disposed(by: disposeBag)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -68,6 +68,8 @@ final class OrderLogViewController: UIViewController, View {
             .distinctUntilChanged()
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, items in
+                print("state")
+                print(items)
                 owner.updateSnapshot(forSection: .order, withItems: items)
             })
             .disposed(by: disposeBag)

--- a/HMOA_iOS/Podfile.lock
+++ b/HMOA_iOS/Podfile.lock
@@ -1152,7 +1152,7 @@ PODS:
   - AppAuth/Core (1.7.5)
   - AppAuth/ExternalUserAgent (1.7.5):
     - AppAuth/Core
-  - AppCheckCore (11.1.0):
+  - AppCheckCore (11.2.0):
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
@@ -1163,8 +1163,8 @@ PODS:
     - BoringSSL-GRPC/Interface (= 0.0.36)
   - BoringSSL-GRPC/Interface (0.0.36)
   - DropDown (2.3.13)
-  - FirebaseAnalytics (11.3.0):
-    - FirebaseAnalytics/AdIdSupport (= 11.3.0)
+  - FirebaseAnalytics (11.4.0):
+    - FirebaseAnalytics/AdIdSupport (= 11.4.0)
     - FirebaseCore (~> 11.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
@@ -1172,36 +1172,36 @@ PODS:
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAnalytics/AdIdSupport (11.3.0):
+  - FirebaseAnalytics/AdIdSupport (11.4.0):
     - FirebaseCore (~> 11.0)
     - FirebaseInstallations (~> 11.0)
-    - GoogleAppMeasurement (= 11.3.0)
+    - GoogleAppMeasurement (= 11.4.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAppCheckInterop (11.3.0)
-  - FirebaseAuth (11.3.0):
+  - FirebaseAppCheckInterop (11.4.0)
+  - FirebaseAuth (11.4.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.0)
-    - FirebaseCoreExtension (~> 11.0)
+    - FirebaseCore (~> 11.4)
+    - FirebaseCoreExtension (~> 11.4)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/Environment (~> 8.0)
-    - GTMSessionFetcher/Core (~> 3.4)
+    - GTMSessionFetcher/Core (< 5.0, >= 3.4)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (11.3.0)
-  - FirebaseCore (11.3.0):
-    - FirebaseCoreInternal (~> 11.0)
+  - FirebaseAuthInterop (11.4.0)
+  - FirebaseCore (11.4.2):
+    - FirebaseCoreInternal (< 12.0, >= 11.4.2)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/Logger (~> 8.0)
-  - FirebaseCoreExtension (11.3.0):
+  - FirebaseCoreExtension (11.4.1):
     - FirebaseCore (~> 11.0)
-  - FirebaseCoreInternal (11.3.0):
+  - FirebaseCoreInternal (11.4.2):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseCrashlytics (11.3.0):
-    - FirebaseCore (~> 11.0)
+  - FirebaseCrashlytics (11.4.0):
+    - FirebaseCore (~> 11.4)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfigInterop (~> 11.0)
     - FirebaseSessions (~> 11.0)
@@ -1209,12 +1209,12 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseFirestore (11.3.0):
-    - FirebaseCore (~> 11.0)
-    - FirebaseCoreExtension (~> 11.0)
-    - FirebaseFirestoreInternal (= 11.3.0)
+  - FirebaseFirestore (11.4.0):
+    - FirebaseCore (~> 11.4)
+    - FirebaseCoreExtension (~> 11.4)
+    - FirebaseFirestoreInternal (= 11.4.0)
     - FirebaseSharedSwift (~> 11.0)
-  - FirebaseFirestoreInternal (11.3.0):
+  - FirebaseFirestoreInternal (11.4.0):
     - abseil/algorithm (~> 1.20240116.1)
     - abseil/base (~> 1.20240116.1)
     - abseil/container/flat_hash_map (~> 1.20240116.1)
@@ -1229,12 +1229,12 @@ PODS:
     - gRPC-Core (~> 1.65.0)
     - leveldb-library (~> 1.22)
     - nanopb (~> 3.30910.0)
-  - FirebaseInstallations (11.3.0):
+  - FirebaseInstallations (11.4.0):
     - FirebaseCore (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (11.3.0):
+  - FirebaseMessaging (11.4.0):
     - FirebaseCore (~> 11.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
@@ -1243,33 +1243,33 @@ PODS:
     - GoogleUtilities/Reachability (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseRemoteConfigInterop (11.3.0)
-  - FirebaseSessions (11.3.0):
-    - FirebaseCore (~> 11.0)
-    - FirebaseCoreExtension (~> 11.0)
+  - FirebaseRemoteConfigInterop (11.4.0)
+  - FirebaseSessions (11.4.0):
+    - FirebaseCore (~> 11.4)
+    - FirebaseCoreExtension (~> 11.4)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (11.3.0)
+  - FirebaseSharedSwift (11.4.0)
   - Gifu (3.3.1)
-  - GoogleAppMeasurement (11.3.0):
-    - GoogleAppMeasurement/AdIdSupport (= 11.3.0)
+  - GoogleAppMeasurement (11.4.0):
+    - GoogleAppMeasurement/AdIdSupport (= 11.4.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/AdIdSupport (11.3.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.3.0)
+  - GoogleAppMeasurement/AdIdSupport (11.4.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.4.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (11.3.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (11.4.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
@@ -1564,26 +1564,26 @@ SPEC CHECKSUMS:
   abseil: d121da9ef7e2ff4cab7666e76c5a3e0915ae08c3
   Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
   AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
-  AppCheckCore: 85a8346f8b5d2f50ee1b9f55d8bcaaeafe904adb
+  AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   BoringSSL-GRPC: ca6a8e5d04812fce8ffd6437810c2d46f925eaeb
   DropDown: 8a2116376c1981888557f72ec2ffc9a5e0e456ec
-  FirebaseAnalytics: ce1593872635a5ebd715d0d3937fab195991ecc9
-  FirebaseAppCheckInterop: 7789a8adfb09e905ce02a76540b94b059029ea81
-  FirebaseAuth: c7b82c8f3942c22629145c3f2972c33d1dc3ee6c
-  FirebaseAuthInterop: c453b7ba7c49b88b2f519bb8d2e29edf7ada4a2a
-  FirebaseCore: 8542de610f35f86196ba26cdb2544565a5157c8e
-  FirebaseCoreExtension: 30bb063476ef66cd46925243d64ad8b2c8ac3264
-  FirebaseCoreInternal: ac26d09a70c730e497936430af4e60fb0c68ec4e
-  FirebaseCrashlytics: ba7b6a55dc10393f6583d87d8600d0d3ab2671d8
-  FirebaseFirestore: e83d088457c90adb2abff42e5c0aaa592151e5ac
-  FirebaseFirestoreInternal: 6492b7efdab5085ccd674e53591d5ebf5065d7f3
-  FirebaseInstallations: 58cf94dabf1e2bb2fa87725a9be5c2249171cda0
-  FirebaseMessaging: ed3f874c733f1d20e32b82a3428f6a9f01ef9270
-  FirebaseRemoteConfigInterop: c3a5c31b3c22079f41ba1dc645df889d9ce38cb9
-  FirebaseSessions: 655ff17f3cc1a635cbdc2d69b953878001f9e25b
-  FirebaseSharedSwift: d39c2ad64a11a8d936ce25a42b00df47078bb59c
+  FirebaseAnalytics: 3feef9ae8733c567866342a1000691baaa7cad49
+  FirebaseAppCheckInterop: 1b9643ae2f1ee214488caa2f8e32b7bc2f0f3735
+  FirebaseAuth: c359af98bd703cbf4293eec107a40de08ede6ce6
+  FirebaseAuthInterop: 9ac948965ac13ec9d8a080f39490ddb2bda30520
+  FirebaseCore: 6b32c57269bd999aab34354c3923d92a6e5f3f84
+  FirebaseCoreExtension: f1bc67a4702931a7caa097d8e4ac0a1b0d16720e
+  FirebaseCoreInternal: 35731192cab10797b88411be84940d2beb33a238
+  FirebaseCrashlytics: 41bbdd2b514a8523cede0c217aee6ef7ecf38401
+  FirebaseFirestore: 2ccdf893fd7e175aa8ec58faa06338b346d27db8
+  FirebaseFirestoreInternal: 004452c4669d5df8869c9f8f7a24ee0009852d5b
+  FirebaseInstallations: 6ef4a1c7eb2a61ee1f74727d7f6ce2e72acf1414
+  FirebaseMessaging: f8a160d99c2c2e5babbbcc90c4a3e15db036aee2
+  FirebaseRemoteConfigInterop: e76f46ffa4d6a65e273d4dfebb6a79e588cec136
+  FirebaseSessions: 3f56f177d9e53a85021d16b31f9a111849d1dd8b
+  FirebaseSharedSwift: 505dae2d05969dbf6d43749a642bb1bf230f0252
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
-  GoogleAppMeasurement: c8bac5f6ad85d3a0bdf2b9aee7fd484d6615d486
+  GoogleAppMeasurement: 987769c4ca6b968f2479fbcc9fe3ce34af454b8e
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d


### PR DESCRIPTION
# 📌 이슈번호
- #292

# 📌 구현/추가 사항
- 향BTI 리뷰 작성 후 옵션 버튼을 통해서 수정 및 삭제, 신고 기능을 구현했습니다.
- 컬렉션뷰, 테이블뷰로 주문내역 등의 아이템을 보여주는 화면에서 아이템이 없는 경우 IconMessageView를 띄우고 안내문구를 사용자에게 보여주도록 했습니다.
- AlertVC에 alertType 속성을 추가하여 로그인 요청 알림이 아닌 경우에는 확인을 눌러도 로그인 화면을 제공하지 않고 알림창 자체만 dismiss 하도록 수정했습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/32052ceb-75f9-4ff7-91ad-d0bb29ec75a0

https://github.com/user-attachments/assets/6e0732ba-7b31-4461-b553-79f80e53f32a




