### PR TITLE
[Refactoring] 닉네임 중복 체크 방식 변경

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/MemberAPI.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Network/API/Member/MemberAPI.swift
@@ -43,12 +43,6 @@ final class MemberAPI {
         .map { result -> Bool in
             return result
         }
-        .catch { error -> Observable<Bool> in
-            if let statusCode = error.asAFError?.responseCode, statusCode == 409 {
-                return Observable.just(true)
-            }
-            return Observable.error(error)
-        }
     }
     
     /// 닉네임 업데이트

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/Start/Reactor/NicknameReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/Start/Reactor/NicknameReactor.swift
@@ -40,10 +40,7 @@ class NicknameReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .didTapDuplicateButton:
-            guard let nickname = currentState.nickname
-            else { return .just(.setIsDuplicate(true))}
-            
-            if nickname.isEmpty { return .just(.setIsDuplicate(true))}
+            guard let nickname = currentState.nickname else { return .empty() }
             
             return .concat([
                 MemberAPI.checkDuplicateNickname(params: ["nickname": nickname])
@@ -51,8 +48,7 @@ class NicknameReactor: Reactor {
                 .just(.setNickname(nickname))
             ])
         case .didTapStartButton:
-            guard let nickname = currentState.nickname
-            else { return .just(.setIsPushNextVC(false)) }
+            guard currentState.nickname != nil else { return .just(.setIsPushNextVC(false)) }
             return .concat([
                 .just(.setIsPushNextVC(true)),
                 .just(.setIsPushNextVC(false))

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/Start/Reactor/NicknameReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Login/Start/Reactor/NicknameReactor.swift
@@ -44,7 +44,7 @@ class NicknameReactor: Reactor {
             
             return .concat([
                 MemberAPI.checkDuplicateNickname(params: ["nickname": nickname])
-                .map { .setIsDuplicate($0) },
+                    .map { .setIsDuplicate($0) },
                 .just(.setNickname(nickname))
             ])
         case .didTapStartButton:

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
@@ -178,9 +178,7 @@ final class HBTIReviewListViewController: UIViewController, View {
             .map { $0.reviewList }
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, item in
-                if reactor.currentState.isLog {
-                    owner.updateCollectionViewIsHidden(isHidden: item.isEmpty)
-                }
+                owner.updateCollectionViewIsHidden(isHidden: item.isEmpty && reactor.currentState.isLog)
                 owner.updateSnapshot(forSection: .review, withItem: item)
             })
             .disposed(by: disposeBag)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Reactor/ChangeProfileImageReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Reactor/ChangeProfileImageReactor.swift
@@ -69,14 +69,11 @@ class ChangeProfileImageReactor: Reactor {
             return updateProfile(image)
             
         case .didTapDuplicateButton(let nickname):
-            guard let nickname = nickname
-            else { return .just(.setIsDuplicate(true))}
-            
-            if nickname.isEmpty { return .just(.setIsDuplicate(true))}
+            guard let nickname = nickname else { return .empty() }
             
             return .concat([
                 MemberAPI.checkDuplicateNickname(params: ["nickname": nickname])
-                .map { .setIsDuplicate($0) },
+                    .map { .setIsDuplicate($0) },
                 .just(.setNickname(nickname))
             ])
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Viewcontroller/ChangeProfileImageViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/MyProfile/Viewcontroller/ChangeProfileImageViewController.swift
@@ -113,7 +113,6 @@ extension ChangeProfileImageViewController {
             .compactMap { $0 }
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, isDuplicate in
-                owner.view.endEditing(true)
                 owner.changeCaptionLabelColor(isDuplicate)
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
# 📌 이슈번호
- #295

# 📌 구현/추가 사항
- 닉네임 중복체크 API 응답 방식 변경에 따라 불필요한 에러처리를 삭제했습니다.
- 프로필 수정 화면에서 닉네임 중복체크 시 키보드가 내려가고 다시 올라오지 않는 버그가 발견되어 일시적으로 이를 해결했습니다. 중복체크 시 키보드가 내려가는게 맞을지, 사용자가 빈화면을 탭할 경우에만 키보드를 내리는 게 맞을지 팀원분들과 상의해야할 것 같습니다.
- 리뷰리스트의 noItemView와 collectionView의 숨김을 처리하는 메서드를 마이페이지에서의 리스트에서만 실행하던 기존 로직에서 항상 실행하되 입력값으로 마이페이지임을 함께 체크하도록 하여 알맞은 동작을 하도록 수정했습니다.

# 📷 미리보기
