### PR TITLE
[UI] 환불이후 환불완료 팝업창 추가

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		C99E7B6B2BA9F0B500F359BC /* MagazineDetailLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99E7B6A2BA9F0B500F359BC /* MagazineDetailLineView.swift */; };
 		C9B02B492CA24A0F00F1107C /* OrderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B02B482CA24A0F00F1107C /* OrderCell.swift */; };
 		C9B02B4D2CA25A0E00F1107C /* OrderCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B02B4C2CA25A0E00F1107C /* OrderCategoryView.swift */; };
+		C9B78B4B2CDF52900051EA7D /* AlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B78B4A2CDF52900051EA7D /* AlertType.swift */; };
 		C9C594962CC8E2F30072382A /* HBTIHomeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C594952CC8E2F30072382A /* HBTIHomeSection.swift */; };
 		C9C594982CC8E3B80072382A /* HBTIHomeSurvey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C594972CC8E3B80072382A /* HBTIHomeSurvey.swift */; };
 		C9C5949A2CC8E4BB0072382A /* HBTIHomeSurveyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C594992CC8E4BB0072382A /* HBTIHomeSurveyCell.swift */; };
@@ -610,6 +611,7 @@
 		C99E7B6A2BA9F0B500F359BC /* MagazineDetailLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineDetailLineView.swift; sourceTree = "<group>"; };
 		C9B02B482CA24A0F00F1107C /* OrderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCell.swift; sourceTree = "<group>"; };
 		C9B02B4C2CA25A0E00F1107C /* OrderCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCategoryView.swift; sourceTree = "<group>"; };
+		C9B78B4A2CDF52900051EA7D /* AlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertType.swift; sourceTree = "<group>"; };
 		C9C594952CC8E2F30072382A /* HBTIHomeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIHomeSection.swift; sourceTree = "<group>"; };
 		C9C594972CC8E3B80072382A /* HBTIHomeSurvey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIHomeSurvey.swift; sourceTree = "<group>"; };
 		C9C594992CC8E4BB0072382A /* HBTIHomeSurveyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBTIHomeSurveyCell.swift; sourceTree = "<group>"; };
@@ -1567,6 +1569,7 @@
 			children = (
 				2C1BD6BB299785360059A43D /* EmptyPerfumeView.swift */,
 				CA5C9B102AB71C6D007D04BA /* AlertViewController.swift */,
+				C9B78B4A2CDF52900051EA7D /* AlertType.swift */,
 				C96CD7462BA8802E005C9856 /* SupplementaryViewKind.swift */,
 				C9819D762C3302260046FE55 /* IconMessageView.swift */,
 			);
@@ -3669,6 +3672,7 @@
 				3F5565FC2C6F32EC005CCBCA /* HBTIProcessGuideViewController.swift in Sources */,
 				CA7C9C0B2AAADF8500072AB9 /* CommunityListViewController.swift in Sources */,
 				C9C5949A2CC8E4BB0072382A /* HBTIHomeSurveyCell.swift in Sources */,
+				C9B78B4B2CDF52900051EA7D /* AlertType.swift in Sources */,
 				CA9B9D812B1B29F9006BBA10 /* MyPageSwitchCell.swift in Sources */,
 				CAFB9F4029B5C67B0009654C /* LoginReactor.swift in Sources */,
 				C96CD7412BA88010005C9856 /* MagazineDetailReactor.swift in Sources */,

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -71,6 +71,12 @@ extension UIViewController {
             self.present(alertVC, animated: false)
     }
     
+    /// 미리 정의된 AlertVC를 입력으로 받아 present
+    func presentAlertVC(alertVC: AlertViewController) {
+        alertVC.modalPresentationStyle = .overFullScreen
+        self.present(alertVC, animated: false)
+    }
+    
     /// communityListVC -> communityDetailVC
     func presentCommunityDetailVC(_ id: Int, _ reactor: CommunityListReactor) {
         let CommunityDetailVC = CommunityDetailViewController()

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -65,8 +65,8 @@ extension UIViewController {
     }
     
     /// CustomAlertVC로 present
-    func presentAlertVC(title: String, content: String, buttonTitle: String, type: AlertType? = nil, orderId: Int? = nil) {
-            let alertVC = AlertViewController(title: title, content: content, buttonTitle: buttonTitle, type: type, orderId: orderId)
+    func presentAlertVC(title: String, content: String, buttonTitle: String, type: AlertType? = nil) {
+            let alertVC = AlertViewController(title: title, content: content, buttonTitle: buttonTitle, type: type)
             alertVC.modalPresentationStyle = .overFullScreen
             self.present(alertVC, animated: false)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertType.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertType.swift
@@ -7,6 +7,6 @@
 
 enum AlertType {
     case login
-    case order
+    case order(Order)
     case none
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertType.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertType.swift
@@ -1,0 +1,12 @@
+//
+//  AlertType.swift
+//  HMOA_iOS
+//
+//  Created by 곽다은 on 11/9/24.
+//
+
+enum AlertType {
+    case login
+    case order
+    case none
+}

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertType.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertType.swift
@@ -7,6 +7,6 @@
 
 enum AlertType {
     case login
-    case order(Order)
+    case refund(Order?)
     case none
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
@@ -13,6 +13,7 @@ import RxSwift
 
 final class AlertViewController: UIViewController {
     
+    // MARK: - Componenets
     let alertView = UIView().then {
         $0.backgroundColor = .white
     }
@@ -36,6 +37,8 @@ final class AlertViewController: UIViewController {
 
     var alertType: AlertType = .login
     
+    // MARK: - Properties
+    let confirmButtonTapped = PublishSubject<Void>()
     let disposeBag = DisposeBag()
 
     init(title: String, content: String, buttonTitle: String, type: AlertType? = nil) {
@@ -46,7 +49,7 @@ final class AlertViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    // MARK: - UIComponents
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -129,13 +132,11 @@ final class AlertViewController: UIViewController {
                                               buttonTitle: "확인",
                                               type: .refund(nil))
                     } else {
-                        owner.dismiss(animated: false) {
-                            // TODO: presentingVC pop
-                        }
+                        owner.confirmButtonTapped.onNext(())
+                        owner.dismiss(animated: false)
                     }
                     
                 case .none:
-                    print("alert type none")
                     owner.dismiss(animated: false)
                 }
             }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
@@ -35,13 +35,11 @@ final class AlertViewController: UIViewController {
     }
 
     var alertType: AlertType = .login
-    var orderId: Int?
     
     let disposeBag = DisposeBag()
 
-    init(title: String, content: String, buttonTitle: String, type: AlertType? = nil, orderId: Int? = nil) {
+    init(title: String, content: String, buttonTitle: String, type: AlertType? = nil) {
         super .init(nibName: nil, bundle: nil)
-        self.orderId = orderId
         self.updateAlertView(title: title, content: content, buttonTitle: buttonTitle, type: type)
     }
     
@@ -60,6 +58,8 @@ final class AlertViewController: UIViewController {
     
     private func setUpUI() {
         view.backgroundColor = UIColor.black.withAlphaComponent(0.3)
+        alertView.layer.cornerRadius = 5
+        alertView.clipsToBounds = true
     }
     
     private func setAddView() {
@@ -119,12 +119,10 @@ final class AlertViewController: UIViewController {
                     owner.dismiss(animated: false) {
                         presentingVC.present(loginVC, animated: true)
                     }
-                case .order:
-                    if let orderId = owner.orderId {
-                        HBTIAPI.deletePurchase(orderId: orderId)
-                            .subscribe()
-                            .disposed(by: owner.disposeBag)
-                    }
+                case .order(let order):
+                    HBTIAPI.deletePurchase(orderId: order.id)
+                        .subscribe()
+                        .disposed(by: owner.disposeBag)
                                        
                     owner.dismiss(animated: false)
                     
@@ -142,10 +140,5 @@ final class AlertViewController: UIViewController {
         
         guard let type = type else { return }
         alertType = type
-        
-        if alertType == .order {
-            alertView.layer.cornerRadius = 5
-            alertView.clipsToBounds = true
-        }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
@@ -32,7 +32,6 @@ final class AlertViewController: UIViewController {
     let bottomButton = UIButton().then {
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.font = .customFont(.pretendard, 12)
-        $0.backgroundColor = .customColor(.gray3)
     }
 
     var alertType: AlertType = .login
@@ -63,6 +62,7 @@ final class AlertViewController: UIViewController {
         view.backgroundColor = UIColor.black.withAlphaComponent(0.3)
         alertView.layer.cornerRadius = 5
         alertView.clipsToBounds = true
+        setBottomButtonBackgroundColor()
     }
     
     private func setAddView() {
@@ -143,12 +143,25 @@ final class AlertViewController: UIViewController {
             .disposed(by: disposeBag)
     }
     
-    func updateAlertView(title: String, content: String, buttonTitle: String, type: AlertType?) {
+    
+}
+
+extension AlertViewController {
+    private func updateAlertView(title: String, content: String, buttonTitle: String, type: AlertType?) {
         titleLabel.text = title
         contentLabel.text = content
         bottomButton.setTitle(buttonTitle, for: .normal)
         
         guard let type = type else { return }
         alertType = type
+    }
+    
+    private func setBottomButtonBackgroundColor() {
+        switch alertType {
+        case .refund(let _):
+            bottomButton.backgroundColor = .black
+        default:
+            bottomButton.backgroundColor = .customColor(.gray3)
+        }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
@@ -127,6 +127,9 @@ final class AlertViewController: UIViewController {
                     }
                                        
                     owner.dismiss(animated: false)
+                    
+                case .none:
+                    owner.dismiss(animated: false)
                 }
             }
             .disposed(by: disposeBag)
@@ -145,9 +148,4 @@ final class AlertViewController: UIViewController {
             alertView.clipsToBounds = true
         }
     }
-}
-
-enum AlertType {
-    case login
-    case order
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/AlertViewController.swift
@@ -119,14 +119,23 @@ final class AlertViewController: UIViewController {
                     owner.dismiss(animated: false) {
                         presentingVC.present(loginVC, animated: true)
                     }
-                case .order(let order):
-                    HBTIAPI.deletePurchase(orderId: order.id)
-                        .subscribe()
-                        .disposed(by: owner.disposeBag)
-                                       
-                    owner.dismiss(animated: false)
+                case .refund(let order):
+                    if let order = order {
+                        HBTIAPI.deletePurchase(orderId: order.id)
+                            .subscribe()
+                            .disposed(by: owner.disposeBag)
+                        owner.updateAlertView(title: "환불이 완료되었습니다.",
+                                              content: "환불은 환불 규정에 따라 진행됩니다.",
+                                              buttonTitle: "확인",
+                                              type: .refund(nil))
+                    } else {
+                        owner.dismiss(animated: false) {
+                            // TODO: presentingVC pop
+                        }
+                    }
                     
                 case .none:
+                    print("alert type none")
                     owner.dismiss(animated: false)
                 }
             }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTI/ViewController/HBTIViewController.swift
@@ -138,7 +138,7 @@ final class HBTIViewController: UIViewController, View {
                     owner.presentAlertVC(title: "주문 후 이용가능한 서비스입니다",
                                          content: "향료 주문 후 이용해주세요",
                                          buttonTitle: "확인",
-                                         type: .order)
+                                         type: .none)
                 }
             })
             .disposed(by: disposeBag)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIReviewList/ViewController/HBTIReviewListViewController.swift
@@ -193,7 +193,7 @@ final class HBTIReviewListViewController: UIViewController, View {
                     owner.presentAlertVC(title: "주문 후 이용가능한 서비스입니다",
                                          content: "배송 후 후기를 작성해주세요",
                                          buttonTitle: "확인",
-                                         type: .order)
+                                         type: .none)
                 } else {
                     owner.showFloatingButtonAnimation(
                         floatingButton: owner.floatingButton,

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
@@ -123,14 +123,12 @@ final class OrderCancelDetailViewController: UIViewController, View {
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, _ in
                 let request = reactor.currentState.requestKind
-                let order = reactor.currentState.order.order!
-                if request == .refundRequest {
-                    owner.presentAlertVC(
-                        title: "환불하시겠습니까?",
-                        content: "환불은 환불 규정에 따라 진행됩니다.",
-                        buttonTitle: "확인",
-                        type: .refund(order))
-                } else {
+                switch request {
+                case .refundRequest:
+                    let order = reactor.currentState.order.order!
+                    let alertVC = owner.createRefundAlertVC(order: order)
+                    owner.presentAlertVC(alertVC: alertVC)
+                case .returnRequest:
                     owner.presentKakaoChannel()
                 }
                 
@@ -287,5 +285,21 @@ extension OrderCancelDetailViewController {
                 }
             }
             .disposed(by: disposeBag)
+    }
+    
+    private func createRefundAlertVC(order: Order) -> AlertViewController {
+        let alertVC = AlertViewController(title: "환불하시겠습니까?",
+                                          content: "환불은 환불 규정에 따라 진행됩니다.",
+                                          buttonTitle: "확인",
+                                          type: .refund(order))
+        
+        alertVC.confirmButtonTapped
+            .asDriver(onErrorRecover: { _ in .empty() })
+            .drive(with: self, onNext: { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+        
+        return alertVC
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
@@ -129,8 +129,7 @@ final class OrderCancelDetailViewController: UIViewController, View {
                         title: "환불하시겠습니까?",
                         content: "환불은 환불 규정에 따라 진행됩니다.",
                         buttonTitle: "확인",
-                        type: .order(order)
-                    )
+                        type: .refund(order))
                 } else {
                     owner.presentKakaoChannel()
                 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
@@ -123,15 +123,13 @@ final class OrderCancelDetailViewController: UIViewController, View {
             .asDriver(onErrorRecover: { _ in .empty() })
             .drive(with: self, onNext: { owner, _ in
                 let request = reactor.currentState.requestKind
+                let order = reactor.currentState.order.order!
                 if request == .refundRequest {
-                    guard let orderId = reactor.currentState.order.order?.id else { return }
-                    
                     owner.presentAlertVC(
                         title: "환불하시겠습니까?",
                         content: "환불은 환불 규정에 따라 진행됩니다.",
                         buttonTitle: "확인",
-                        type: .order,
-                        orderId: orderId
+                        type: .order(order)
                     )
                 } else {
                     owner.presentKakaoChannel()

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderCancelDetail/ViewController/OrderCancelDetailViewController.swift
@@ -131,7 +131,6 @@ final class OrderCancelDetailViewController: UIViewController, View {
                 case .returnRequest:
                     owner.presentKakaoChannel()
                 }
-                
             })
             .disposed(by: disposeBag)
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Reactor/OrderLogReactor.swift
@@ -12,7 +12,7 @@ final class OrderLogReactor: Reactor {
     
     enum Action {
         case viewWillAppear
-        case viewWillDisappear
+        case viewDidDisappear
         case loadNextPage
         case didTapRefundButton(OrderLogItem)
         case didTapReturnButton(OrderLogItem)
@@ -49,7 +49,7 @@ final class OrderLogReactor: Reactor {
         case .viewWillAppear:
             return setOrderList()
             
-        case .viewWillDisappear:
+        case .viewDidDisappear:
             return .concat([
                 .just(.setNextPage(0)),
                 .just(.setOrderList([]))

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
@@ -250,6 +250,8 @@ extension OrderCell {
     private func setButtonComposition(for status: OrderStatus?) {
         guard let status = status else { return }
         
+        buttonStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
         switch status {
         case .PAY_COMPLETE:
             buttonStackView.addArrangedSubview(refundRequestButton)

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
@@ -89,7 +89,6 @@ final class OrderCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        setUI()
         setAddView()
         setConstraints()
     }
@@ -100,15 +99,10 @@ final class OrderCell: UICollectionViewCell {
     
     override func prepareForReuse() {
             super.prepareForReuse()
-        
             disposeBag = DisposeBag()
         }
     
     // MARK: - Function
-    
-    private func setUI() {
-        
-    }
     
     private func setAddView() {
         [

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -61,8 +61,8 @@ final class OrderLogViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
-        rx.viewWillDisappear
-            .map { _ in Reactor.Action.viewWillDisappear }
+        rx.viewDidDisappear
+            .map { _ in Reactor.Action.viewDidDisappear }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         


### PR DESCRIPTION
# 📌 이슈번호
- #315

# 📌 구현/추가 사항
- AlertType에 none case를 추가하고, order case를 refund로 변경한 후, Order 연관값을 갖도록 하여 환불Alert일 때 orderID 전달하는 방식을 변경해주었습니다.
- 원래는 환불alert dismiss 해주고 환불완료 팝업을 새로 present하려고 했는데, 굳이 그럴 필요 없이 타이틀라벨만 변경해주면 될 것 같아서 같은 AlertVC 인스턴스를 사용하도록 구현했습니다.
- 주문내역VC을 pop하거나 다른 VC로 push할 때 orderList state를 비워주는걸 viewWillDisappear에서 하고 있었는데, 이렇게 하니까 주문내역이 없다는 뷰가 일시적으로 보이는 현상이 있어서 viewDidDisappear에서 하도록 변경했습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/5601b8d0-eb8d-415d-b96f-a21a0cff41db