### PR TITLE
[UI] 가격대 우선시 향수 없을 때 안내화면 추가

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/IconMessageView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/IconMessageView.swift
@@ -69,7 +69,7 @@ class IconMessageView: UIView {
         iconImageView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.top.equalToSuperview()
-            make.width.equalTo(iconWidth)
+            make.width.height.equalTo(iconWidth)
         }
         
         if titleLabel.text != "제목" {

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/IconMessageView.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Comon/View/IconMessageView.swift
@@ -12,10 +12,6 @@ import Then
 
 class IconMessageView: UIView {
     
-    // MARK: - Properties
-    
-    private let iconWidth: CGFloat
-    
     // MARK: - Components
     
     private let iconImageView = UIImageView().then {
@@ -25,6 +21,8 @@ class IconMessageView: UIView {
     private let titleLabel = UILabel().then {
         $0.font = .customFont(.pretendard_bold, 22)
         $0.setTextWithLineHeight(text: "제목", lineHeight: 28)
+        $0.numberOfLines = 0
+        $0.textAlignment = .center
     }
     
     private let descriptionLabel = UILabel().then {
@@ -34,15 +32,14 @@ class IconMessageView: UIView {
     
     // MARK: - Initialize
     
-    init(title: String? = nil, description: String? = nil, iconWidth: CGFloat) {
-        self.iconWidth = iconWidth
+    init(title: String? = nil, description: String? = nil, iconWidth: CGFloat, titleOffSet: CGFloat = 24, descriptionOffset: CGFloat = 62) {
         super.init(frame: .zero)
     
         titleLabel.text = title
         descriptionLabel.text = description
         
         setAddView()
-        setConstraints()
+        setConstraints(iconWidth, titleOffSet, descriptionOffset)
     }
     
     required init?(coder: NSCoder) {
@@ -65,7 +62,7 @@ class IconMessageView: UIView {
         subViews.forEach { addSubview($0) }
     }
     
-    private func setConstraints() {
+    private func setConstraints(_ iconWidth: CGFloat, _ titleOffset: CGFloat, _ descriptionOffset: CGFloat) {
         iconImageView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.top.equalToSuperview()
@@ -75,14 +72,14 @@ class IconMessageView: UIView {
         if titleLabel.text != "제목" {
             titleLabel.snp.makeConstraints { make in
                 make.centerX.equalToSuperview()
-                make.top.equalTo(iconImageView.snp.bottom).offset(24)
+                make.top.equalTo(iconImageView.snp.bottom).offset(titleOffset)
             }
         }
         
         if descriptionLabel.text != "설명" {
             descriptionLabel.snp.makeConstraints { make in
                 make.centerX.equalToSuperview()
-                make.top.equalTo(titleLabel.snp.bottom).offset(62)
+                make.top.equalTo(titleLabel.snp.bottom).offset(descriptionOffset)
                 make.bottom.equalToSuperview()
             }
         }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -36,7 +36,9 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
     private let noMatchPerfumeView = IconMessageView(
         title: "설정하신 가격대 내에\n해당하는 향수가 없습니다.",
         description: "가격대를 재설정 해주세요.",
-        iconWidth: 90
+        iconWidth: 90,
+        titleOffSet: 44,
+        descriptionOffset: 12
     ).then {
         $0.isHidden = true
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -48,14 +48,7 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
                     forCellWithReuseIdentifier: HBTIPerfumeResultCell.identifier)
     }
     
-    private let nextButton = UIButton().then {
-        $0.setTitle("다음", for: .normal)
-        $0.titleLabel?.font = .customFont(.pretendard, 15)
-        $0.setTitleColor(.white, for: .normal)
-        $0.layer.cornerRadius = 5
-        $0.backgroundColor = .black
-        $0.isEnabled = true
-    }
+    private let nextButton = UIButton().makeValidHBTINextButton(title: "홈으로 돌아가기")
     
     // MARK: - Properties
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIPerfumeResult/ViewController/HBTIPerfumeResultViewController.swift
@@ -33,6 +33,14 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         $0.isSelected = true
     }
     
+    private let noMatchPerfumeView = IconMessageView(
+        title: "설정하신 가격대 내에\n해당하는 향수가 없습니다.",
+        description: "가격대를 재설정 해주세요.",
+        iconWidth: 90
+    ).then {
+        $0.isHidden = true
+    }
+    
     private lazy var perfumeCollectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout()).then {
         $0.register(HBTIPerfumeResultCell.self,
                     forCellWithReuseIdentifier: HBTIPerfumeResultCell.identifier)
@@ -108,6 +116,7 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
                 owner.togglePriority(priority)
                 
                 let items = reactor.currentState.perfumeList
+                owner.hideCollectionView(when: items.isEmpty)
                 owner.updateSnapshot(forSection: .perfume, withItems: items)
             })
             .disposed(by: disposeBag)
@@ -150,6 +159,7 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
             priceButton,
             noteButton,
             perfumeCollectionView,
+            noMatchPerfumeView,
             nextButton
         ].forEach { view.addSubview($0) }
     }
@@ -176,6 +186,11 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
         perfumeCollectionView.snp.makeConstraints { make in
             make.top.equalTo(priceButton.snp.bottom).offset(22)
             make.horizontalEdges.bottom.equalToSuperview()
+        }
+        
+        noMatchPerfumeView.snp.makeConstraints { make in
+            make.top.equalTo(priceButton.snp.bottom).offset(65)
+            make.centerX.equalToSuperview()
         }
         
         nextButton.snp.makeConstraints { make in
@@ -241,5 +256,10 @@ final class HBTIPerfumeResultViewController: UIViewController, View {
     private func togglePriority(_ priority: HBTIPerfumeResultPriority) {
         priceButton.isSelected = priority == .price
         noteButton.isSelected = priority == .note
+    }
+    
+    private func hideCollectionView(when noItem: Bool) {
+        perfumeCollectionView.isHidden = noItem
+        noMatchPerfumeView.isHidden = !noItem
     }
 }


### PR DESCRIPTION
# 📌 이슈번호
- #320

# 📌 구현/추가 사항
- IconMessageView 초기화 시 title과 description의 오프셋 값을 입력받아 뷰의 constraints를 커스텀할 수 있도록 수정했습니다.
- 향료를 어떻게 설정해야 향수가 안뜨는지 알아내기가 어려워서 임의로 item을 비우도록 하여 뷰를 확인했습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/0c5e785f-bd82-4c09-9857-6e76d3341140


