### PR TITLE
[UI] 향BTI 이벤트 내용 문구 추가

### DIFF
--- a/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
+++ b/HMOA_iOS/HMOA_iOS.xcodeproj/project.pbxproj
@@ -4015,7 +4015,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.1.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.hyungyu.HMOA-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4065,7 +4065,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.1.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.hyungyu.HMOA-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Extenstions/UIViewController++Extenstions.swift
@@ -450,9 +450,10 @@ extension UIViewController {
         let backButton = self.navigationItem.makeImageButtonItem(self, action: #selector(popViewController), imageName: "backButton")
         
         let homeButton = self.navigationItem.makeImageButtonItem(self, action: #selector(goToHome), imageName: "homeNavi")
-
+        
         let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .white
+        appearance.shadowColor = .clear
+        appearance.backgroundEffect = nil
         
         self.navigationController?.navigationBar.standardAppearance = appearance
         self.navigationController?.navigationBar.compactAppearance = appearance
@@ -474,7 +475,6 @@ extension UIViewController {
         let backButton = self.navigationItem.makeImageButtonItem(self, action: #selector(popViewController), imageName: "backButton")
         
         let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .white
         appearance.shadowColor = .white
         
         self.navigationController?.navigationBar.standardAppearance = appearance
@@ -520,16 +520,18 @@ extension UIViewController {
         self.navigationItem.titleView = titleLabel
         self.navigationItem.leftBarButtonItems = [backButton]
 
-        let standardAppearance = UINavigationBarAppearance()
-        standardAppearance.backgroundColor = .clear
-        standardAppearance.shadowColor = .clear
-        standardAppearance.backgroundEffect = nil
-        standardAppearance.titleTextAttributes = [
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = .clear
+        appearance.shadowColor = .clear
+        appearance.backgroundEffect = nil
+        appearance.titleTextAttributes = [
             NSAttributedString.Key.font: UIFont.customFont(.pretendard_bold, 20),
             NSAttributedString.Key.foregroundColor: UIColor.white
         ]
         
-        self.navigationController?.navigationBar.standardAppearance = standardAppearance
+        self.navigationController?.navigationBar.standardAppearance = appearance
+        self.navigationController?.navigationBar.compactAppearance = appearance
+        self.navigationController?.navigationBar.scrollEdgeAppearance = appearance
     }
     
     // 투명 배경과 흰색 back버튼 NavigationBar
@@ -648,7 +650,8 @@ extension UIViewController {
         self.navigationItem.titleView = searchBarWrapper
         
         let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .white
+        appearance.shadowColor = .clear
+        appearance.backgroundEffect = nil
         
         self.navigationController?.navigationBar.standardAppearance = appearance
         self.navigationController?.navigationBar.compactAppearance = appearance

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/Reactor/HomeViewReactor.swift
@@ -89,7 +89,7 @@ final class HomeViewReactor: Reactor {
             return .concat([
                 .just(.setIsTapHBTI(true)),
                 .just(.setIsTapHBTI(nil))
-                ])
+            ])
         }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/View/HomeTopCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/View/HomeTopCell.swift
@@ -45,8 +45,19 @@ class HomeTopCell: UICollectionViewCell {
     }
     
     // MARK: - Lifecycle
-    override func layoutSubviews() {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
         configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        disposeBag = DisposeBag()
     }
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/Home/ViewController/HomeViewController.swift
@@ -162,6 +162,7 @@ class HomeViewController: UIViewController, View {
             })
             .disposed(by: disposeBag)
         
+        // 향BTI 버튼 탭
         reactor.state
             .compactMap { $0.isTapHBTI }
             .asDriver(onErrorRecover: { _ in return .empty() })
@@ -204,11 +205,6 @@ extension HomeViewController {
                 homeTopCell.hbtiButton.rx.tap
                     .map { Reactor.Action.didTapHBTIButton }
                     .bind(to: self.reactor!.action)
-                    .disposed(by: self.disposeBag)
-                
-                self.reactor!.state
-                    .compactMap { $0.isTapHBTI }
-                    .bind(to: homeTopCell.hbtiButton.rx.isSelected)
                     .disposed(by: homeTopCell.disposeBag)
                 
                 return homeTopCell

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Model/OrderLogSection.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/Model/OrderLogSection.swift
@@ -26,6 +26,47 @@ extension OrderLogItem {
     
     static let exampleOrder: [OrderLogItem] = [
         .order(Order(
+            id: 3,
+            status: OrderStatus.SHIPPING_COMPLETE.rawValue,
+            products: OrderInfo(
+                categoryListInfo: HBTICategoryListInfo(
+                    totalPrice: 75000,
+                    categoryList: [
+                        HBTICategory(
+                            id: 5,
+                            name: "프루티",
+                            imageURL: "https://example.com/fruity.jpeg",
+                            noteCount: 3,
+                            noteList: [
+                                HBTINote(name: "복숭아", content: "달콤하고 부드러운 복숭아 향"),
+                                HBTINote(name: "블랙베리", content: "진하고 달콤한 블랙베리 향"),
+                                HBTINote(name: "자몽", content: "새콤하고 상큼한 자몽 향")
+                            ],
+                            price: 35000
+                        ),
+                        HBTICategory(
+                            id: 6,
+                            name: "그린",
+                            imageURL: "https://example.com/green.jpeg",
+                            noteCount: 2,
+                            noteList: [
+                                HBTINote(name: "바질", content: "상쾌하고 풍부한 허브 향"),
+                                HBTINote(name: "파인", content: "산뜻하고 시원한 솔잎 향")
+                            ],
+                            price: 40000
+                        )
+                    ]
+                ),
+                paymentAmount: 75000,
+                shippingFee: 3500,
+                totalAmount: 78500
+            ),
+            createdAt: "2024/09/26",
+            courierCompany: "한진택배",
+            trackingNumber: "0987654321",
+            isReviewed: false
+        )),
+        .order(Order(
             id: 1,
             status: OrderStatus.PAY_COMPLETE.rawValue,
             products: OrderInfo(
@@ -93,47 +134,6 @@ extension OrderLogItem {
             createdAt: "2024/09/25",
             courierCompany: "대한통운",
             trackingNumber: "1234567890",
-            isReviewed: false
-        )),
-        .order(Order(
-            id: 3,
-            status: OrderStatus.SHIPPING_COMPLETE.rawValue,
-            products: OrderInfo(
-                categoryListInfo: HBTICategoryListInfo(
-                    totalPrice: 75000,
-                    categoryList: [
-                        HBTICategory(
-                            id: 5,
-                            name: "프루티",
-                            imageURL: "https://example.com/fruity.jpeg",
-                            noteCount: 3,
-                            noteList: [
-                                HBTINote(name: "복숭아", content: "달콤하고 부드러운 복숭아 향"),
-                                HBTINote(name: "블랙베리", content: "진하고 달콤한 블랙베리 향"),
-                                HBTINote(name: "자몽", content: "새콤하고 상큼한 자몽 향")
-                            ],
-                            price: 35000
-                        ),
-                        HBTICategory(
-                            id: 6,
-                            name: "그린",
-                            imageURL: "https://example.com/green.jpeg",
-                            noteCount: 2,
-                            noteList: [
-                                HBTINote(name: "바질", content: "상쾌하고 풍부한 허브 향"),
-                                HBTINote(name: "파인", content: "산뜻하고 시원한 솔잎 향")
-                            ],
-                            price: 40000
-                        )
-                    ]
-                ),
-                paymentAmount: 75000,
-                shippingFee: 3500,
-                totalAmount: 78500
-            ),
-            createdAt: "2024/09/26",
-            courierCompany: "한진택배",
-            trackingNumber: "0987654321",
             isReviewed: false
         ))
     ]

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/View/OrderCell.swift
@@ -73,7 +73,7 @@ final class OrderCell: UICollectionViewCell {
     
     private let buttonStackView = UIStackView().then {
         $0.axis = .horizontal
-        $0.alignment = .fill
+        $0.alignment = .top
         $0.distribution = .fillEqually
         $0.spacing = 20
     }
@@ -82,7 +82,7 @@ final class OrderCell: UICollectionViewCell {
     
     let returnRequestButton = UIButton().makeBorderButton(title: "반품 신청", color: .black)
     
-    let reviewButton = UIButton().makeBorderButton(title: "후기 작성", color: .black)
+    let reviewButton = UIButton().makeBorderButton(title: "후기 작성(이벤트 자동 응모)", color: .black)
     
     // MARK: - Init
     
@@ -192,9 +192,20 @@ final class OrderCell: UICollectionViewCell {
         buttonStackView.snp.makeConstraints { make in
             make.top.equalTo(totalAmountTitleLabel.snp.bottom).offset(32)
             make.horizontalEdges.bottom.equalToSuperview()
+            make.height.greaterThanOrEqualTo(32)
+        }
+        
+        refundRequestButton.snp.makeConstraints { make in
             make.height.equalTo(32)
         }
         
+        returnRequestButton.snp.makeConstraints { make in
+            make.height.equalTo(32)
+        }
+        
+        reviewButton.snp.makeConstraints { make in
+            make.height.equalTo(32)
+        }
     }
     
     func configureCell(order: Order) {
@@ -258,10 +269,7 @@ extension OrderCell {
         case .SHIPPING_PROGRESS:
             buttonStackView.addArrangedSubview(returnRequestButton)
         case .SHIPPING_COMPLETE:
-            [
-                returnRequestButton,
-                reviewButton
-            ]   .forEach { buttonStackView.addArrangedSubview($0) }
+            setButtonCompositionWhenShippingComplete()
         default:
             break
         }
@@ -270,5 +278,30 @@ extension OrderCell {
     private func setReviewButtonEnabled(isReviewed: Bool) {
         reviewButton.isEnabled = !isReviewed
         reviewButton.layer.borderColor = isReviewed ? UIColor.customColor(.gray3).cgColor : UIColor.black.cgColor
+    }
+    
+    private func setButtonCompositionWhenShippingComplete() {
+        let reviewStack = UIStackView().then  {
+            $0.axis = .vertical
+            $0.alignment = .fill
+            $0.spacing = 6
+        }
+        
+        let eventLabel = UILabel().then {
+            $0.setLabelUI("", font: .pretendard, size: 10, color: .black)
+            $0.setTextWithLineHeight(text: "(5만원 상당 향수 증정 이벤트 응모)\n자세한 내용은 향모아 인스타그램에서 확인하세요.", lineHeight: 12)
+            $0.numberOfLines = 0
+            $0.lineBreakStrategy = .standard
+        }
+        
+        [
+            reviewButton,
+            eventLabel
+        ].forEach { reviewStack.addArrangedSubview($0) }
+        
+        [
+            returnRequestButton,
+            reviewStack
+        ]   .forEach { buttonStackView.addArrangedSubview($0) }
     }
 }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/MyPage/OrderLog/ViewController/OrderLogViewController.swift
@@ -193,6 +193,7 @@ final class OrderLogViewController: UIViewController, View {
         
         var initialSnapshot = NSDiffableDataSourceSnapshot<OrderLogSection, OrderLogItem>()
         initialSnapshot.appendSections([.order])
+        initialSnapshot.appendItems(OrderLogItem.exampleOrder)
         
         dataSource?.apply(initialSnapshot, animatingDifferences: false)
     }


### PR DESCRIPTION
# 📌 이슈번호
- #329

# 📌 구현/추가 사항
- 마이페이지 주문내역의 후기작성 버튼 문구 수정 및 그 아래에 이벤트 내용을 안내하는 라벨을 추가했습니다
- 다른 활동 하다가 메인 화면의 향BTI 버튼을 눌렀을 때 간혹 중복적으로 향BTIVC가 push되는 경우가 있었는데, 이를 해결했습니다. 우선은 구독 시 cell의 disposeBag을 사용하지 않고 있던 것을 수정하였고, prepareForReuse를 통해 셀 재사용 시 구독을 해제하도록 변경했습니다. 이렇게 수정하고 테스트했을 때는 이상 없었는데, 테스트를 통해서 좀 더 검증해볼 필요가 있을 것 같습니다.
- DetailVC나 BrandSearchVC에서 사용하는 네비바에서 background를 .white로 지정하여 명시적으로 흰색을 사용하던 것 때문에 향BTI 홈과 같은 검은색 배경에 투명 네비바를 사용하는 VC에서 네비바 배경이 흰색으로 바뀌는 현상이 발생하여 .white를 할당하는 부분을 삭제했습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/2f1a6f74-69ed-4249-93e4-4ec36b642116
