### PR TITLE
[Bug] 향BTI 1차 후반부 페이지 네비게이션 및 주문서 결제하기 버튼 비활성화 문제

### DIFF
--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIAddFixAdress/Reactor/HBTIAddFixReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIAddFixAdress/Reactor/HBTIAddFixReactor.swift
@@ -139,16 +139,17 @@ final class HBTIAddFixReactor: Reactor {
             state.isPushVC = isPush
         }
         
-        state.isEnabledSaveButton = isValid(name: state.name, phoneNumber: state.phoneNumber, zipCode: state.zipCode, address: state.address, detailAddress: state.detailAddress)
+        state.isEnabledSaveButton = isValid(name: state.name, phoneNumber: state.phoneNumber, telephoneNumber: state.telephoneNumber, zipCode: state.zipCode, address: state.address, detailAddress: state.detailAddress)
         
         return state
     }
 }
 
 extension HBTIAddFixReactor {
-    func isValid(name: String, phoneNumber: String, zipCode: String, address: String, detailAddress: String) -> Bool {
+    func isValid(name: String, phoneNumber: String, telephoneNumber: String, zipCode: String, address: String, detailAddress: String) -> Bool {
         return !name.isEmpty
             && isValidPhoneNumber(phoneNumber)
+            && (telephoneNumber == "--" || isValidTelephoneNumber(telephoneNumber))
             && !zipCode.isEmpty
             && !address.isEmpty
             && !detailAddress.isEmpty
@@ -159,6 +160,13 @@ extension HBTIAddFixReactor {
         let predicate = NSPredicate(format: "SELF MATCHES %@", phoneRegex)
             
         return predicate.evaluate(with: phoneNumber)
+    }
+    
+    func isValidTelephoneNumber(_ telephoneNumber: String) -> Bool {
+        let telephoneRegex = "^(010|02|031|032|033|041|042|043|044|051|052|053|054|055|061|062|063|064)-(\\d{3}|\\d{4})-\\d{4}$"
+        let predicate = NSPredicate(format: "SELF MATCHES %@", telephoneRegex)
+            
+        return predicate.evaluate(with: telephoneNumber)
     }
 }
 

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIAddFixAdress/Reactor/HBTIAddFixReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIAddFixAdress/Reactor/HBTIAddFixReactor.swift
@@ -95,7 +95,8 @@ final class HBTIAddFixReactor: Reactor {
             return .concat([
                     .just(.setIsEnabledSaveButton(isEnabled)),
                     isEnabled ? postMemberAddressInfo() : .empty(),
-                    .just(.setIsPushVC(isEnabled))
+                    .just(.setIsPushVC(isEnabled)),
+                    .just(.setIsPushVC(false))
                 ])
         }
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/Reactor/HBTINotesCategoryReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesCategory/Reactor/HBTINotesCategoryReactor.swift
@@ -62,7 +62,10 @@ final class HBTINotesCategoryReactor: Reactor {
         case .didTapNextButton:
             let isEnabled = currentState.isEnabledNextButton
             
-            return .just(.setIsPushNextVC(isEnabled))
+            return .concat([
+                .just(.setIsPushNextVC(isEnabled)),
+                .just(.setIsPushNextVC(false))
+            ])
         }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesResult/Reactor/HBTINotesResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTINotesResult/Reactor/HBTINotesResultReactor.swift
@@ -45,7 +45,8 @@ final class HBTINotesResultReactor: Reactor {
         case .didTapNextButton:
             return .concat([
                 setOrderId(),
-                .just(.setIsPushNextVC(true))
+                .just(.setIsPushNextVC(true)),
+                .just(.setIsPushNextVC(false))
             ])
         }
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIOrderSheet/Reactor/HBTIOrderReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIOrderSheet/Reactor/HBTIOrderReactor.swift
@@ -172,18 +172,17 @@ final class HBTIOrderReactor: Reactor {
             state.isPersonalInfoAgree = isPersonalInfoAgree
         }
         
-        state.isPayValid = isValid(state.name, state.phoneNumber, state.isAllAgree, state.telephoneNumber, state.address, state.zipCode)
+        state.isPayValid = isValid(state.name, state.phoneNumber, state.isAllAgree, state.address, state.zipCode)
         
         return state
     }
 }
 
 extension HBTIOrderReactor {
-    private func isValid(_ name: String, _ phoneNumber: String, _ isAllAgree: Bool, _ telephoneNumber: String, _ address: String, _ zipCode: String) -> Bool {
+    private func isValid(_ name: String, _ phoneNumber: String, _ isAllAgree: Bool, _ address: String, _ zipCode: String) -> Bool {
         return !name.isEmpty
             && isValidPhoneNumber(phoneNumber)
             && isAllAgree
-            && isValidPhoneNumber(telephoneNumber)
             && !address.isEmpty
             && !zipCode.isEmpty
     }

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIProcessGuide/Reactor/HBTIProcessGuideReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTIProcessGuide/Reactor/HBTIProcessGuideReactor.swift
@@ -31,7 +31,10 @@ final class HBTIProcessGuideReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .didTapNextButton:
-            return .just(.setIsPushNextVC(true))
+            return .concat([
+                .just(.setIsPushNextVC(true)),
+                .just(.setIsPushNextVC(false))
+            ])
         }
     }
     

--- a/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
+++ b/HMOA_iOS/HMOA_iOS/Source/Presentation/Tab/Home/HBTI/HBTISurveyResult/Reactor/HBTISurveyResultReactor.swift
@@ -17,7 +17,7 @@ final class HBTISurveyResultReactor: Reactor {
     enum Mutation {
         case setNoteItemList([HBTISurveyResultItem])
         case setNickname(String)
-        case setIsPushNextVC
+        case setIsPushNextVC(Bool)
     }
     
     struct State {
@@ -41,7 +41,10 @@ final class HBTISurveyResultReactor: Reactor {
                 setNoteItemList()
             ])
         case .isTapNextButton:
-            return .just(.setIsPushNextVC)
+            return .concat([
+                .just(.setIsPushNextVC(true)),
+                .just(.setIsPushNextVC(false))
+            ])
         }
     }
     
@@ -55,8 +58,8 @@ final class HBTISurveyResultReactor: Reactor {
         case .setNickname(let nickname):
             state.nickname = nickname
             
-        case .setIsPushNextVC:
-            state.isPushNextVC = true
+        case .setIsPushNextVC(let isPushNextVC):
+            state.isPushNextVC = isPushNextVC
         }
         
         return state


### PR DESCRIPTION
# 📌 이슈번호
- #335 

# 📌 구현/추가 사항
- 향BTI 1차 후반부에서 이전 페이지로 넘어갈 시 "다음" 버튼이 정상 작동하지 않는 문제를 해결했습니다.
- 향BTI 1차 후반부의 주문서 페이지에서 결제하기 버튼의 비활성화 버그를 해결했습니다.

# 📷 미리보기
https://github.com/user-attachments/assets/59413e0f-1a1f-4262-a461-b1ddd29d2109

https://github.com/user-attachments/assets/cc20297c-0477-4145-99f5-ade528e28b0b

https://github.com/user-attachments/assets/b8893450-479f-44c5-aab2-fe0b7ead0093

https://github.com/user-attachments/assets/d54511b3-a827-4427-99c0-38906bc435ad

https://github.com/user-attachments/assets/c6238cf7-2db4-429f-84e2-f5046b1ef187

https://github.com/user-attachments/assets/75c5c06d-9d23-4a49-b381-0a51523a351f